### PR TITLE
feat(rec-02): recruitment pipeline backend + 90% recruitment coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,9 @@ jobs:
       # once FND-09 lands (tracked in docs/specs/foundations/FND-09).
       - name: Lint, test, build (affected)
         run: pnpm turbo run lint test build --filter="${{ steps.affected.outputs.filter }}"
+
+      # Coverage gate: recruitment code (src/services/recruitment/**) must stay ≥90% (statements,
+      # branches, functions, lines) or this fails. Scoped on purpose — the rest of the backend is
+      # not yet gated. Widen the include/thresholds in backend/vitest.config.ts as suites grow.
+      - name: Recruitment coverage gate (backend ≥90%)
+        run: pnpm --filter ganzafrica-backend test:coverage

--- a/backend/drizzle/0005_recruitment_pipeline.sql
+++ b/backend/drizzle/0005_recruitment_pipeline.sql
@@ -1,0 +1,71 @@
+CREATE TABLE "application_scores" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"application_id" integer NOT NULL,
+	"criterion_id" integer NOT NULL,
+	"reviewer_user_id" integer NOT NULL,
+	"score" integer NOT NULL,
+	"comment" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "application_stage_events" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"application_id" integer NOT NULL,
+	"from_stage" text,
+	"to_stage" text NOT NULL,
+	"actor_user_id" integer,
+	"note" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "evaluation_criteria" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"opportunity_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"weight" numeric(5, 2) DEFAULT '1' NOT NULL,
+	"max_score" integer DEFAULT 5 NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "recruitment_emails" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"application_id" integer NOT NULL,
+	"email_type" text NOT NULL,
+	"sent_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "screening_rules" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"opportunity_id" integer NOT NULL,
+	"field_key" text NOT NULL,
+	"operator" text NOT NULL,
+	"value" jsonb,
+	"action" text NOT NULL,
+	"email_template" text,
+	"rejection_reason" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"hit_count" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "applications" ADD COLUMN "pipeline_stage" text DEFAULT 'submitted' NOT NULL;--> statement-breakpoint
+ALTER TABLE "applications" ADD COLUMN "rejection_reason" text;--> statement-breakpoint
+ALTER TABLE "applications" ADD COLUMN "flagged" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "applications" ADD COLUMN "flag_note" text;--> statement-breakpoint
+ALTER TABLE "application_scores" ADD CONSTRAINT "application_scores_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "application_scores" ADD CONSTRAINT "application_scores_criterion_id_evaluation_criteria_id_fk" FOREIGN KEY ("criterion_id") REFERENCES "public"."evaluation_criteria"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "application_scores" ADD CONSTRAINT "application_scores_reviewer_user_id_users_id_fk" FOREIGN KEY ("reviewer_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "application_stage_events" ADD CONSTRAINT "application_stage_events_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "application_stage_events" ADD CONSTRAINT "application_stage_events_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "evaluation_criteria" ADD CONSTRAINT "evaluation_criteria_opportunity_id_opportunities_id_fk" FOREIGN KEY ("opportunity_id") REFERENCES "public"."opportunities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recruitment_emails" ADD CONSTRAINT "recruitment_emails_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "screening_rules" ADD CONSTRAINT "screening_rules_opportunity_id_opportunities_id_fk" FOREIGN KEY ("opportunity_id") REFERENCES "public"."opportunities"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "app_score_uniq" ON "application_scores" USING btree ("application_id","criterion_id","reviewer_user_id");--> statement-breakpoint
+CREATE INDEX "stage_events_app_idx" ON "application_stage_events" USING btree ("application_id");--> statement-breakpoint
+CREATE INDEX "evaluation_criteria_opportunity_id_idx" ON "evaluation_criteria" USING btree ("opportunity_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "recruitment_email_once" ON "recruitment_emails" USING btree ("application_id","email_type");--> statement-breakpoint
+CREATE INDEX "screening_rules_opportunity_id_idx" ON "screening_rules" USING btree ("opportunity_id");

--- a/backend/drizzle/meta/0005_snapshot.json
+++ b/backend/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,9908 @@
+{
+  "id": "6c4fd671-dddd-4bea-9572-3d69c92d51e0",
+  "prevId": "c4ed5e51-9b40-46e1-a989-0afdc63c36b8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievement_comments": {
+      "name": "achievement_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "achievement_comments_achievement_id_alumni_achievements_id_fk": {
+          "name": "achievement_comments_achievement_id_alumni_achievements_id_fk",
+          "tableFrom": "achievement_comments",
+          "tableTo": "alumni_achievements",
+          "columnsFrom": ["achievement_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "achievement_comments_user_id_users_id_fk": {
+          "name": "achievement_comments_user_id_users_id_fk",
+          "tableFrom": "achievement_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.achievement_likes": {
+      "name": "achievement_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "achievement_likes_achievement_id_alumni_achievements_id_fk": {
+          "name": "achievement_likes_achievement_id_alumni_achievements_id_fk",
+          "tableFrom": "achievement_likes",
+          "tableTo": "alumni_achievements",
+          "columnsFrom": ["achievement_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "achievement_likes_user_id_users_id_fk": {
+          "name": "achievement_likes_user_id_users_id_fk",
+          "tableFrom": "achievement_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alumni_achievements": {
+      "name": "alumni_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization": {
+          "name": "organization",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alumni_achievements_user_id_users_id_fk": {
+          "name": "alumni_achievements_user_id_users_id_fk",
+          "tableFrom": "alumni_achievements",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alumni_events": {
+      "name": "alumni_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_virtual": {
+          "name": "is_virtual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "meeting_url": {
+          "name": "meeting_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizer": {
+          "name": "organizer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_paid": {
+          "name": "is_paid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Open'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "speakers": {
+          "name": "speakers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "agenda": {
+          "name": "agenda",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alumni_events_organizer_id_users_id_fk": {
+          "name": "alumni_events_organizer_id_users_id_fk",
+          "tableFrom": "alumni_events",
+          "tableTo": "users",
+          "columnsFrom": ["organizer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alumni_mentorships": {
+      "name": "alumni_mentorships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mentor_id": {
+          "name": "mentor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentee_id": {
+          "name": "mentee_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "total_sessions": {
+          "name": "total_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alumni_mentorships_mentor_id_users_id_fk": {
+          "name": "alumni_mentorships_mentor_id_users_id_fk",
+          "tableFrom": "alumni_mentorships",
+          "tableTo": "users",
+          "columnsFrom": ["mentor_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "alumni_mentorships_mentee_id_users_id_fk": {
+          "name": "alumni_mentorships_mentee_id_users_id_fk",
+          "tableFrom": "alumni_mentorships",
+          "tableTo": "users",
+          "columnsFrom": ["mentee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alumni_profiles": {
+      "name": "alumni_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industry": {
+          "name": "industry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "graduation_year": {
+          "name": "graduation_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fellow_role": {
+          "name": "fellow_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alumni_profiles_user_id_users_id_fk": {
+          "name": "alumni_profiles_user_id_users_id_fk",
+          "tableFrom": "alumni_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "alumni_profiles_user_id_unique": {
+          "name": "alumni_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.alumni_resources": {
+      "name": "alumni_resources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_title": {
+          "name": "author_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "estimated_time": {
+          "name": "estimated_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating_sum": {
+          "name": "rating_sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "rating_count": {
+          "name": "rating_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "alumni_resources_author_id_users_id_fk": {
+          "name": "alumni_resources_author_id_users_id_fk",
+          "tableFrom": "alumni_resources",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_registrations": {
+      "name": "event_registrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Registered'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_registrations_event_id_alumni_events_id_fk": {
+          "name": "event_registrations_event_id_alumni_events_id_fk",
+          "tableFrom": "event_registrations",
+          "tableTo": "alumni_events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_registrations_user_id_users_id_fk": {
+          "name": "event_registrations_user_id_users_id_fk",
+          "tableFrom": "event_registrations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_opportunities": {
+      "name": "job_opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_remote": {
+          "name": "is_remote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "salary_min": {
+          "name": "salary_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_max": {
+          "name": "salary_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salary_currency": {
+          "name": "salary_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirements": {
+          "name": "requirements",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "sector": {
+          "name": "sector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experience_level": {
+          "name": "experience_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_url": {
+          "name": "application_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'internal'"
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "posted_by": {
+          "name": "posted_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "job_opportunities_posted_by_users_id_fk": {
+          "name": "job_opportunities_posted_by_users_id_fk",
+          "tableFrom": "job_opportunities",
+          "tableTo": "users",
+          "columnsFrom": ["posted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mentorship_goals": {
+      "name": "mentorship_goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mentorship_id": {
+          "name": "mentorship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mentorship_goals_mentorship_id_alumni_mentorships_id_fk": {
+          "name": "mentorship_goals_mentorship_id_alumni_mentorships_id_fk",
+          "tableFrom": "mentorship_goals",
+          "tableTo": "alumni_mentorships",
+          "columnsFrom": ["mentorship_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mentorship_sessions": {
+      "name": "mentorship_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "mentorship_id": {
+          "name": "mentorship_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mentorship_sessions_mentorship_id_alumni_mentorships_id_fk": {
+          "name": "mentorship_sessions_mentorship_id_alumni_mentorships_id_fk",
+          "tableFrom": "mentorship_sessions",
+          "tableTo": "alumni_mentorships",
+          "columnsFrom": ["mentorship_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_downloads": {
+      "name": "resource_downloads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_downloads_resource_id_alumni_resources_id_fk": {
+          "name": "resource_downloads_resource_id_alumni_resources_id_fk",
+          "tableFrom": "resource_downloads",
+          "tableTo": "alumni_resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_downloads_user_id_users_id_fk": {
+          "name": "resource_downloads_user_id_users_id_fk",
+          "tableFrom": "resource_downloads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_likes": {
+      "name": "resource_likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_likes_resource_id_alumni_resources_id_fk": {
+          "name": "resource_likes_resource_id_alumni_resources_id_fk",
+          "tableFrom": "resource_likes",
+          "tableTo": "alumni_resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_likes_user_id_users_id_fk": {
+          "name": "resource_likes_user_id_users_id_fk",
+          "tableFrom": "resource_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_ratings": {
+      "name": "resource_ratings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "review": {
+          "name": "review",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "resource_ratings_resource_id_alumni_resources_id_fk": {
+          "name": "resource_ratings_resource_id_alumni_resources_id_fk",
+          "tableFrom": "resource_ratings",
+          "tableTo": "alumni_resources",
+          "columnsFrom": ["resource_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "resource_ratings_user_id_users_id_fk": {
+          "name": "resource_ratings_user_id_users_id_fk",
+          "tableFrom": "resource_ratings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changes": {
+          "name": "changes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_handoff_codes": {
+      "name": "auth_handoff_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_app": {
+          "name": "target_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_handoff_codes_user_id_users_id_fk": {
+          "name": "auth_handoff_codes_user_id_users_id_fk",
+          "tableFrom": "auth_handoff_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_handoff_codes_code_hash_unique": {
+          "name": "auth_handoff_codes_code_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'global'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.newsletter_subscribers": {
+      "name": "newsletter_subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "newsletter_subscribers_email_unique": {
+          "name": "newsletter_subscribers_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faqs": {
+      "name": "faqs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faqs_is_active_idx": {
+          "name": "faqs_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_asset_categories": {
+      "name": "hr_asset_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_name": {
+          "name": "parent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec_schema": {
+          "name": "spec_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hr_asset_categories_slug_unique": {
+          "name": "hr_asset_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_asset_images": {
+      "name": "hr_asset_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_asset_images_asset_id_hr_assets_id_fk": {
+          "name": "hr_asset_images_asset_id_hr_assets_id_fk",
+          "tableFrom": "hr_asset_images",
+          "tableTo": "hr_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_asset_maintenance": {
+      "name": "hr_asset_maintenance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_id": {
+          "name": "requester_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requester_employee_id": {
+          "name": "requester_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "maintenance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maintenance_date": {
+          "name": "maintenance_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_asset_maintenance_asset_id_hr_assets_id_fk": {
+          "name": "hr_asset_maintenance_asset_id_hr_assets_id_fk",
+          "tableFrom": "hr_asset_maintenance",
+          "tableTo": "hr_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_asset_maintenance_requester_id_hr_users_id_fk": {
+          "name": "hr_asset_maintenance_requester_id_hr_users_id_fk",
+          "tableFrom": "hr_asset_maintenance",
+          "tableTo": "hr_users",
+          "columnsFrom": ["requester_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hr_asset_maintenance_requester_employee_id_employees_id_fk": {
+          "name": "hr_asset_maintenance_requester_employee_id_employees_id_fk",
+          "tableFrom": "hr_asset_maintenance",
+          "tableTo": "employees",
+          "columnsFrom": ["requester_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_asset_specs": {
+      "name": "hr_asset_specs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec_key": {
+          "name": "spec_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec_value": {
+          "name": "spec_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_asset_specs_asset_id_hr_assets_id_fk": {
+          "name": "hr_asset_specs_asset_id_hr_assets_id_fk",
+          "tableFrom": "hr_asset_specs",
+          "tableTo": "hr_assets",
+          "columnsFrom": ["asset_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hr_asset_specs_asset_id_spec_key_unique": {
+          "name": "hr_asset_specs_asset_id_spec_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["asset_id", "spec_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_assets": {
+      "name": "hr_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purchase_price": {
+          "name": "purchase_price",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "asset_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AVAILABLE'"
+        },
+        "assigned_to_id": {
+          "name": "assigned_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_employee_id": {
+          "name": "assigned_to_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returned_at": {
+          "name": "returned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_issue": {
+          "name": "has_issue",
+          "type": "asset_issue",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NO'"
+        },
+        "is_flagged": {
+          "name": "is_flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_assets_category_id_hr_asset_categories_id_fk": {
+          "name": "hr_assets_category_id_hr_asset_categories_id_fk",
+          "tableFrom": "hr_assets",
+          "tableTo": "hr_asset_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hr_assets_assigned_to_id_hr_users_id_fk": {
+          "name": "hr_assets_assigned_to_id_hr_users_id_fk",
+          "tableFrom": "hr_assets",
+          "tableTo": "hr_users",
+          "columnsFrom": ["assigned_to_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "hr_assets_assigned_to_employee_id_employees_id_fk": {
+          "name": "hr_assets_assigned_to_employee_id_employees_id_fk",
+          "tableFrom": "hr_assets",
+          "tableTo": "employees",
+          "columnsFrom": ["assigned_to_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hr_assets_serial_number_unique": {
+          "name": "hr_assets_serial_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["serial_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_contracts": {
+      "name": "hr_contracts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_ref_id": {
+          "name": "employee_ref_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_location": {
+          "name": "work_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager": {
+          "name": "manager",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_to": {
+          "name": "report_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employment_term": {
+          "name": "employment_term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employment_type": {
+          "name": "employment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "days_per_week": {
+          "name": "days_per_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compensation_type": {
+          "name": "compensation_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "salary_scale": {
+          "name": "salary_scale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'RWF'"
+        },
+        "base_monthly_rate": {
+          "name": "base_monthly_rate",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_annual_rate": {
+          "name": "gross_annual_rate",
+          "type": "numeric(14, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employment_agreement_url": {
+          "name": "employment_agreement_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "contract_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_contracts_employee_id_hr_users_id_fk": {
+          "name": "hr_contracts_employee_id_hr_users_id_fk",
+          "tableFrom": "hr_contracts",
+          "tableTo": "hr_users",
+          "columnsFrom": ["employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_contracts_employee_ref_id_employees_id_fk": {
+          "name": "hr_contracts_employee_ref_id_employees_id_fk",
+          "tableFrom": "hr_contracts",
+          "tableTo": "employees",
+          "columnsFrom": ["employee_ref_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_documents": {
+      "name": "hr_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_name": {
+          "name": "document_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_category": {
+          "name": "document_category",
+          "type": "policy_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "policy_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "access": {
+          "name": "access",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contract_id": {
+          "name": "contract_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_employee_id": {
+          "name": "created_by_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_documents_contract_id_hr_contracts_id_fk": {
+          "name": "hr_documents_contract_id_hr_contracts_id_fk",
+          "tableFrom": "hr_documents",
+          "tableTo": "hr_contracts",
+          "columnsFrom": ["contract_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hr_documents_created_by_id_hr_users_id_fk": {
+          "name": "hr_documents_created_by_id_hr_users_id_fk",
+          "tableFrom": "hr_documents",
+          "tableTo": "hr_users",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "hr_documents_created_by_employee_id_employees_id_fk": {
+          "name": "hr_documents_created_by_employee_id_employees_id_fk",
+          "tableFrom": "hr_documents",
+          "tableTo": "employees",
+          "columnsFrom": ["created_by_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_otps": {
+      "name": "hr_otps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_otps_created_by_id_hr_users_id_fk": {
+          "name": "hr_otps_created_by_id_hr_users_id_fk",
+          "tableFrom": "hr_otps",
+          "tableTo": "hr_users",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_users": {
+      "name": "hr_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "hr_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "requires_password_reset": {
+          "name": "requires_password_reset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profile_setup_completed": {
+          "name": "profile_setup_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_users_platform_user_id_users_id_fk": {
+          "name": "hr_users_platform_user_id_users_id_fk",
+          "tableFrom": "hr_users",
+          "tableTo": "users",
+          "columnsFrom": ["platform_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hr_users_platform_user_id_unique": {
+          "name": "hr_users_platform_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["platform_user_id"]
+        },
+        "hr_users_personal_email_unique": {
+          "name": "hr_users_personal_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["personal_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employees": {
+      "name": "employees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_hr_user_id": {
+          "name": "legacy_hr_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employee_number": {
+          "name": "employee_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_email": {
+          "name": "work_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_email": {
+          "name": "personal_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture": {
+          "name": "picture",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_country": {
+          "name": "home_country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "home_city": {
+          "name": "home_city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employment_type": {
+          "name": "employment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'staff'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "hired_at": {
+          "name": "hired_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exited_at": {
+          "name": "exited_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "employees_user_id_users_id_fk": {
+          "name": "employees_user_id_users_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "employees_manager_id_employees_id_fk": {
+          "name": "employees_manager_id_employees_id_fk",
+          "tableFrom": "employees",
+          "tableTo": "employees",
+          "columnsFrom": ["manager_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "employees_user_id_unique": {
+          "name": "employees_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "employees_legacy_hr_user_id_unique": {
+          "name": "employees_legacy_hr_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["legacy_hr_user_id"]
+        },
+        "employees_employee_number_unique": {
+          "name": "employees_employee_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["employee_number"]
+        },
+        "employees_work_email_unique": {
+          "name": "employees_work_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["work_email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "employees_employment_type_check": {
+          "name": "employees_employment_type_check",
+          "value": "\"employees\".\"employment_type\" IN ('fellow','analyst','staff','contractor','intern')"
+        },
+        "employees_status_check": {
+          "name": "employees_status_check",
+          "value": "\"employees\".\"status\" IN ('onboarding','active','on_leave','offboarding','exited')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.hr_helpdesk_tickets": {
+      "name": "hr_helpdesk_tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_id": {
+          "name": "submitted_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_employee_id": {
+          "name": "submitted_by_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_id": {
+          "name": "assigned_to_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to_employee_id": {
+          "name": "assigned_to_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "ticket_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDIUM'"
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_helpdesk_tickets_submitted_by_id_hr_users_id_fk": {
+          "name": "hr_helpdesk_tickets_submitted_by_id_hr_users_id_fk",
+          "tableFrom": "hr_helpdesk_tickets",
+          "tableTo": "hr_users",
+          "columnsFrom": ["submitted_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_helpdesk_tickets_submitted_by_employee_id_employees_id_fk": {
+          "name": "hr_helpdesk_tickets_submitted_by_employee_id_employees_id_fk",
+          "tableFrom": "hr_helpdesk_tickets",
+          "tableTo": "employees",
+          "columnsFrom": ["submitted_by_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_helpdesk_tickets_assigned_to_id_hr_users_id_fk": {
+          "name": "hr_helpdesk_tickets_assigned_to_id_hr_users_id_fk",
+          "tableFrom": "hr_helpdesk_tickets",
+          "tableTo": "hr_users",
+          "columnsFrom": ["assigned_to_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "hr_helpdesk_tickets_assigned_to_employee_id_employees_id_fk": {
+          "name": "hr_helpdesk_tickets_assigned_to_employee_id_employees_id_fk",
+          "tableFrom": "hr_helpdesk_tickets",
+          "tableTo": "employees",
+          "columnsFrom": ["assigned_to_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_leaves": {
+      "name": "hr_leaves",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "leave_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "leave_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_employee_id": {
+          "name": "reviewed_by_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_leaves_user_id_hr_users_id_fk": {
+          "name": "hr_leaves_user_id_hr_users_id_fk",
+          "tableFrom": "hr_leaves",
+          "tableTo": "hr_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_leaves_employee_id_employees_id_fk": {
+          "name": "hr_leaves_employee_id_employees_id_fk",
+          "tableFrom": "hr_leaves",
+          "tableTo": "employees",
+          "columnsFrom": ["employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "hr_leaves_reviewed_by_id_hr_users_id_fk": {
+          "name": "hr_leaves_reviewed_by_id_hr_users_id_fk",
+          "tableFrom": "hr_leaves",
+          "tableTo": "hr_users",
+          "columnsFrom": ["reviewed_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "hr_leaves_reviewed_by_employee_id_employees_id_fk": {
+          "name": "hr_leaves_reviewed_by_employee_id_employees_id_fk",
+          "tableFrom": "hr_leaves",
+          "tableTo": "employees",
+          "columnsFrom": ["reviewed_by_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_policies": {
+      "name": "hr_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_category": {
+          "name": "policy_category",
+          "type": "hr_policy_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'GENERAL'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downloads": {
+          "name": "downloads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "hr_policy_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PUBLISHED'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_employee_id": {
+          "name": "created_by_employee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_policies_created_by_id_hr_users_id_fk": {
+          "name": "hr_policies_created_by_id_hr_users_id_fk",
+          "tableFrom": "hr_policies",
+          "tableTo": "hr_users",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "hr_policies_created_by_employee_id_employees_id_fk": {
+          "name": "hr_policies_created_by_employee_id_employees_id_fk",
+          "tableFrom": "hr_policies",
+          "tableTo": "employees",
+          "columnsFrom": ["created_by_employee_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_notification_preferences": {
+      "name": "hr_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_enabled": {
+          "name": "email_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "contract_expiry": {
+          "name": "contract_expiry",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "leave_updates": {
+          "name": "leave_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "ticket_updates": {
+          "name": "ticket_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "asset_updates": {
+          "name": "asset_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "policy_updates": {
+          "name": "policy_updates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_notification_preferences_user_id_users_id_fk": {
+          "name": "hr_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "hr_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hr_notification_preferences_user_id_unique": {
+          "name": "hr_notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hr_notifications": {
+      "name": "hr_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "notification_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NORMAL'"
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNREAD'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hr_notifications_recipient_id_users_id_fk": {
+          "name": "hr_notifications_recipient_id_users_id_fk",
+          "tableFrom": "hr_notifications",
+          "tableTo": "users",
+          "columnsFrom": ["recipient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_users_id_fk": {
+          "name": "user_profiles_user_id_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "two_factor_method": {
+          "name": "two_factor_method",
+          "type": "two_factor_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_verified": {
+          "name": "phone_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_password_change": {
+          "name": "last_password_change",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "account_locked": {
+          "name": "account_locked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "failed_login_attempts": {
+          "name": "failed_login_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_attempt": {
+          "name": "last_failed_attempt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_role_id_roles_id_fk": {
+          "name": "users_role_id_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_categories": {
+      "name": "project_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_categories_name_unique": {
+          "name": "project_categories_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_documents": {
+      "name": "project_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_documents_project_id_idx": {
+          "name": "project_documents_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_documents_project_id_projects_id_fk": {
+          "name": "project_documents_project_id_projects_id_fk",
+          "tableFrom": "project_documents",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_members": {
+      "name": "project_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "project_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_idx": {
+          "name": "project_members_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_members_team_id_idx": {
+          "name": "project_members_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_project_team": {
+          "name": "unique_project_team",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_team_id_teams_id_fk": {
+          "name": "project_members_team_id_teams_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_partners": {
+      "name": "project_partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_partners_project_id_idx": {
+          "name": "project_partners_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_partners_partner_id_idx": {
+          "name": "project_partners_partner_id_idx",
+          "columns": [
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_project_partner": {
+          "name": "unique_project_partner",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_partners_project_id_projects_id_fk": {
+          "name": "project_partners_project_id_projects_id_fk",
+          "tableFrom": "project_partners",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_partners_partner_id_partners_id_fk": {
+          "name": "project_partners_partner_id_partners_id_fk",
+          "tableFrom": "project_partners",
+          "tableTo": "partners",
+          "columnsFrom": ["partner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_updates": {
+      "name": "project_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media": {
+          "name": "media",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "update_type": {
+          "name": "update_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_updates_project_id_idx": {
+          "name": "project_updates_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_updates_author_id_idx": {
+          "name": "project_updates_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_updates_project_id_projects_id_fk": {
+          "name": "project_updates_project_id_projects_id_fk",
+          "tableFrom": "project_updates",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_updates_author_id_teams_id_fk": {
+          "name": "project_updates_author_id_teams_id_fk",
+          "tableFrom": "project_updates",
+          "tableTo": "teams",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_description": {
+          "name": "full_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomes": {
+          "name": "outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media": {
+          "name": "media",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "other_information": {
+          "name": "other_information",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_category_id_idx": {
+          "name": "projects_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_partner_id_idx": {
+          "name": "projects_partner_id_idx",
+          "columns": [
+            {
+              "expression": "partner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_status_idx": {
+          "name": "projects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_category_id_project_categories_id_fk": {
+          "name": "projects_category_id_project_categories_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "project_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "projects_partner_id_partners_id_fk": {
+          "name": "projects_partner_id_partners_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "partners",
+          "columnsFrom": ["partner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_hash": {
+          "name": "refresh_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_refresh_hash": {
+          "name": "previous_refresh_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_rotated_at": {
+          "name": "refresh_rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_activity": {
+          "name": "last_activity",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_info": {
+          "name": "device_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor_credentials": {
+      "name": "two_factor_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_credentials_user_id_users_id_fk": {
+          "name": "two_factor_credentials_user_id_users_id_fk",
+          "tableFrom": "two_factor_credentials",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor_temp_tokens": {
+      "name": "two_factor_temp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_temp_tokens_user_id_users_id_fk": {
+          "name": "two_factor_temp_tokens_user_id_users_id_fk",
+          "tableFrom": "two_factor_temp_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "verification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verification_tokens_user_id_users_id_fk": {
+          "name": "verification_tokens_user_id_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_types": {
+      "name": "team_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "team_types_name_unique": {
+          "name": "team_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_link": {
+          "name": "profile_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_type_id": {
+          "name": "team_type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_team_type_id_idx": {
+          "name": "teams_team_type_id_idx",
+          "columns": [
+            {
+              "expression": "team_type_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_email_idx": {
+          "name": "teams_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_sort_order_idx": {
+          "name": "teams_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_team_type_id_team_types_id_fk": {
+          "name": "teams_team_type_id_team_types_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "team_types",
+          "columnsFrom": ["team_type_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partners": {
+      "name": "partners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partners_name_idx": {
+          "name": "partners_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partners_location_idx": {
+          "name": "partners_location_idx",
+          "columns": [
+            {
+              "expression": "location",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupation": {
+          "name": "occupation",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testimonials_author_name_idx": {
+          "name": "testimonials_author_name_idx",
+          "columns": [
+            {
+              "expression": "author_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "testimonials_company_idx": {
+          "name": "testimonials_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "testimonials_rating_idx": {
+          "name": "testimonials_rating_idx",
+          "columns": [
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "news_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_published'"
+        },
+        "publish_date": {
+          "name": "publish_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "news_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'news'"
+        },
+        "key_lessons": {
+          "name": "key_lessons",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "media": {
+          "name": "media",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_status_idx": {
+          "name": "news_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_category_idx": {
+          "name": "news_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_publish_date_idx": {
+          "name": "news_publish_date_idx",
+          "columns": [
+            {
+              "expression": "publish_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_tags": {
+      "name": "news_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "news_tags_name_unique": {
+          "name": "news_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news_to_tags": {
+      "name": "news_to_tags",
+      "schema": "",
+      "columns": {
+        "news_id": {
+          "name": "news_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "news_to_tags_news_id_idx": {
+          "name": "news_to_tags_news_id_idx",
+          "columns": [
+            {
+              "expression": "news_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_to_tags_tag_id_idx": {
+          "name": "news_to_tags_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_to_tags_news_id_news_id_fk": {
+          "name": "news_to_tags_news_id_news_id_fk",
+          "tableFrom": "news_to_tags",
+          "tableTo": "news",
+          "columnsFrom": ["news_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "news_to_tags_tag_id_news_tags_id_fk": {
+          "name": "news_to_tags_tag_id_news_tags_id_fk",
+          "tableFrom": "news_to_tags",
+          "tableTo": "news_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "news_to_tags_news_id_tag_id_pk": {
+          "name": "news_to_tags_news_id_tag_id_pk",
+          "columns": ["news_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_resource_action_idx": {
+          "name": "permissions_resource_action_idx",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_id": {
+          "name": "permission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "role_permissions_role_perm_idx": {
+          "name": "role_permissions_role_perm_idx",
+          "columns": [
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "permission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "role_permissions_permission_id_permissions_id_fk": {
+          "name": "role_permissions_permission_id_permissions_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "permissions",
+          "columnsFrom": ["permission_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_role_idx": {
+          "name": "user_role_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_project_members": {
+      "name": "task_project_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "task_team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_project_members_project_id_idx": {
+          "name": "task_project_members_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_project_members_user_id_idx": {
+          "name": "task_project_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_project_user": {
+          "name": "unique_project_user",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_project_members_project_id_task_team_projects_id_fk": {
+          "name": "task_project_members_project_id_task_team_projects_id_fk",
+          "tableFrom": "task_project_members",
+          "tableTo": "task_team_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_project_members_user_id_users_id_fk": {
+          "name": "task_project_members_user_id_users_id_fk",
+          "tableFrom": "task_project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_team_members": {
+      "name": "task_team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "task_team_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_team_members_team_id_idx": {
+          "name": "task_team_members_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_team_members_user_id_idx": {
+          "name": "task_team_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_team_members_role_idx": {
+          "name": "task_team_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_team_user": {
+          "name": "unique_team_user",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_team_members_team_id_task_teams_id_fk": {
+          "name": "task_team_members_team_id_task_teams_id_fk",
+          "tableFrom": "task_team_members",
+          "tableTo": "task_teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_team_members_user_id_users_id_fk": {
+          "name": "task_team_members_user_id_users_id_fk",
+          "tableFrom": "task_team_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_team_projects": {
+      "name": "task_team_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planning'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_team_projects_team_id_idx": {
+          "name": "task_team_projects_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_team_projects_status_idx": {
+          "name": "task_team_projects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_team_projects_created_by_idx": {
+          "name": "task_team_projects_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_team_projects_team_id_task_teams_id_fk": {
+          "name": "task_team_projects_team_id_task_teams_id_fk",
+          "tableFrom": "task_team_projects",
+          "tableTo": "task_teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_team_projects_created_by_users_id_fk": {
+          "name": "task_team_projects_created_by_users_id_fk",
+          "tableFrom": "task_team_projects",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_teams": {
+      "name": "task_teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_team_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_teams_created_by_idx": {
+          "name": "task_teams_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_teams_status_idx": {
+          "name": "task_teams_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_teams_name_idx": {
+          "name": "task_teams_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_teams_created_by_users_id_fk": {
+          "name": "task_teams_created_by_users_id_fk",
+          "tableFrom": "task_teams",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_task_id_tasks_id_fk": {
+          "name": "task_assignees_task_id_tasks_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_user_id_users_id_fk": {
+          "name": "task_assignees_user_id_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_comments_task_id_idx": {
+          "name": "task_comments_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_comments_user_id_idx": {
+          "name": "task_comments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_comments_user_id_users_id_fk": {
+          "name": "task_comments_user_id_users_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliverables": {
+          "name": "deliverables",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "task_priority",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_project_id_idx": {
+          "name": "tasks_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_status_idx": {
+          "name": "tasks_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_priority_idx": {
+          "name": "tasks_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_created_by_idx": {
+          "name": "tasks_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_due_date_idx": {
+          "name": "tasks_due_date_idx",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_task_team_projects_id_fk": {
+          "name": "tasks_project_id_task_team_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "task_team_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_created_by_users_id_fk": {
+          "name": "tasks_created_by_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_deliverables": {
+      "name": "project_deliverables",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'1.0'"
+        },
+        "is_final": {
+          "name": "is_final",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_deliverables_project_id_idx": {
+          "name": "project_deliverables_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_deliverables_uploaded_by_idx": {
+          "name": "project_deliverables_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_deliverables_file_type_idx": {
+          "name": "project_deliverables_file_type_idx",
+          "columns": [
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "project_deliverables_is_final_idx": {
+          "name": "project_deliverables_is_final_idx",
+          "columns": [
+            {
+              "expression": "is_final",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_deliverables_project_id_task_team_projects_id_fk": {
+          "name": "project_deliverables_project_id_task_team_projects_id_fk",
+          "tableFrom": "project_deliverables",
+          "tableTo": "task_team_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_deliverables_uploaded_by_users_id_fk": {
+          "name": "project_deliverables_uploaded_by_users_id_fk",
+          "tableFrom": "project_deliverables",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_analytics": {
+      "name": "report_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "report_type": {
+          "name": "report_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by": {
+          "name": "generated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_range_start": {
+          "name": "date_range_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_range_end": {
+          "name": "date_range_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filters_applied": {
+          "name": "filters_applied",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_analytics_report_type_idx": {
+          "name": "report_analytics_report_type_idx",
+          "columns": [
+            {
+              "expression": "report_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_analytics_entity_id_idx": {
+          "name": "report_analytics_entity_id_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_analytics_generated_by_idx": {
+          "name": "report_analytics_generated_by_idx",
+          "columns": [
+            {
+              "expression": "generated_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_analytics_generated_at_idx": {
+          "name": "report_analytics_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_analytics_generated_by_users_id_fk": {
+          "name": "report_analytics_generated_by_users_id_fk",
+          "tableFrom": "report_analytics",
+          "tableTo": "users",
+          "columnsFrom": ["generated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_categories": {
+      "name": "report_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_files": {
+      "name": "report_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_files_team_id_idx": {
+          "name": "report_files_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_project_id_idx": {
+          "name": "report_files_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_task_id_idx": {
+          "name": "report_files_task_id_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_uploaded_by_idx": {
+          "name": "report_files_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_category_id_idx": {
+          "name": "report_files_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_files_file_type_idx": {
+          "name": "report_files_file_type_idx",
+          "columns": [
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_files_team_id_task_teams_id_fk": {
+          "name": "report_files_team_id_task_teams_id_fk",
+          "tableFrom": "report_files",
+          "tableTo": "task_teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_files_project_id_task_team_projects_id_fk": {
+          "name": "report_files_project_id_task_team_projects_id_fk",
+          "tableFrom": "report_files",
+          "tableTo": "task_team_projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_files_task_id_tasks_id_fk": {
+          "name": "report_files_task_id_tasks_id_fk",
+          "tableFrom": "report_files",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "report_files_uploaded_by_users_id_fk": {
+          "name": "report_files_uploaded_by_users_id_fk",
+          "tableFrom": "report_files",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "report_files_category_id_report_categories_id_fk": {
+          "name": "report_files_category_id_report_categories_id_fk",
+          "tableFrom": "report_files",
+          "tableTo": "report_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_templates": {
+      "name": "report_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_type": {
+          "name": "template_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "report_templates_template_type_idx": {
+          "name": "report_templates_template_type_idx",
+          "columns": [
+            {
+              "expression": "template_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "report_templates_created_by_idx": {
+          "name": "report_templates_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_templates_created_by_users_id_fk": {
+          "name": "report_templates_created_by_users_id_fk",
+          "tableFrom": "report_templates",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payrolls": {
+      "name": "payrolls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payroll_period": {
+          "name": "payroll_period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_payment": {
+          "name": "date_of_payment",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staff_fellow_number": {
+          "name": "staff_fellow_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employee_id": {
+          "name": "employee_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program": {
+          "name": "program",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payroll_type": {
+          "name": "payroll_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'rwf'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'RWF'"
+        },
+        "basic_salary": {
+          "name": "basic_salary",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_salary": {
+          "name": "gross_salary",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csr_employer": {
+          "name": "csr_employer",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occupational_hazards": {
+          "name": "occupational_hazards",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maternity_employer": {
+          "name": "maternity_employer",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csr_employee": {
+          "name": "csr_employee",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maternity_employee": {
+          "name": "maternity_employee",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tpr": {
+          "name": "tpr",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_salary_before_cbhi": {
+          "name": "net_salary_before_cbhi",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cbhi": {
+          "name": "cbhi",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_salary": {
+          "name": "net_salary",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bnr_exchange_rate_date": {
+          "name": "bnr_exchange_rate_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exchange_rate_used": {
+          "name": "exchange_rate_used",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "net_salary_usd": {
+          "name": "net_salary_usd",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_usd": {
+          "name": "gross_usd",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wop_usd": {
+          "name": "wop_usd",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_rate": {
+          "name": "date_rate",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wop_rwf": {
+          "name": "wop_rwf",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gross_rwf": {
+          "name": "gross_rwf",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "housing_allowance": {
+          "name": "housing_allowance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "function_allowance": {
+          "name": "function_allowance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transport_allowance": {
+          "name": "transport_allowance",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payslip_file_url": {
+          "name": "payslip_file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payslip_file_key": {
+          "name": "payslip_file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_sent": {
+          "name": "email_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_sent_at": {
+          "name": "email_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_error": {
+          "name": "email_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_filename": {
+          "name": "source_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payrolls_user_id_users_id_fk": {
+          "name": "payrolls_user_id_users_id_fk",
+          "tableFrom": "payrolls",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payrolls_uploaded_by_users_id_fk": {
+          "name": "payrolls_uploaded_by_users_id_fk",
+          "tableFrom": "payrolls",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payslip_access_tokens": {
+      "name": "payslip_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payroll_id": {
+          "name": "payroll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "char(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "payslip_tokens_payroll_idx": {
+          "name": "payslip_tokens_payroll_idx",
+          "columns": [
+            {
+              "expression": "payroll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payslip_access_tokens_payroll_id_payrolls_id_fk": {
+          "name": "payslip_access_tokens_payroll_id_payrolls_id_fk",
+          "tableFrom": "payslip_access_tokens",
+          "tableTo": "payrolls",
+          "columnsFrom": ["payroll_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "payslip_access_tokens_token_hash_unique": {
+          "name": "payslip_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_reviews": {
+      "name": "application_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_id": {
+          "name": "reviewer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendation": {
+          "name": "recommendation",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_reviews_application_id_idx": {
+          "name": "application_reviews_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "application_reviews_reviewer_id_idx": {
+          "name": "application_reviews_reviewer_id_idx",
+          "columns": [
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_application_reviewer": {
+          "name": "unique_application_reviewer",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_reviews_application_id_applications_id_fk": {
+          "name": "application_reviews_application_id_applications_id_fk",
+          "tableFrom": "application_reviews",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_reviews_reviewer_id_users_id_fk": {
+          "name": "application_reviews_reviewer_id_users_id_fk",
+          "tableFrom": "application_reviews",
+          "tableTo": "users",
+          "columnsFrom": ["reviewer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_id": {
+          "name": "national_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "education_level": {
+          "name": "education_level",
+          "type": "education_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_of_study": {
+          "name": "field_of_study",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "career_experience": {
+          "name": "career_experience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cv_url": {
+          "name": "cv_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supporting_docs_url": {
+          "name": "supporting_docs_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "motivation": {
+          "name": "motivation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "five_year_vision": {
+          "name": "five_year_vision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_impact": {
+          "name": "desired_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "community_role": {
+          "name": "community_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "national_strategy": {
+          "name": "national_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "how_ganzafrica_can_help": {
+          "name": "how_ganzafrica_can_help",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contribution_to_ganzafrica": {
+          "name": "contribution_to_ganzafrica",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_processing_consent": {
+          "name": "data_processing_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "custom_answers": {
+          "name": "custom_answers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "form_version": {
+          "name": "form_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_residence": {
+          "name": "country_of_residence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_of_work": {
+          "name": "country_of_work",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_work_permit": {
+          "name": "has_work_permit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_stage": {
+          "name": "pipeline_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "flag_note": {
+          "name": "flag_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'submitted'"
+        },
+        "submission_date": {
+          "name": "submission_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_opportunity_id_idx": {
+          "name": "applications_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_status_idx": {
+          "name": "applications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_user_id_idx": {
+          "name": "applications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_opportunity_id_opportunities_id_fk": {
+          "name": "applications_opportunity_id_opportunities_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_user_id_users_id_fk": {
+          "name": "applications_user_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.employment_details": {
+      "name": "employment_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_level": {
+          "name": "position_level",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employment_type": {
+          "name": "employment_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responsibilities": {
+          "name": "responsibilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifications": {
+          "name": "qualifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "employment_details_opportunity_id_idx": {
+          "name": "employment_details_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "employment_details_opportunity_id_opportunities_id_fk": {
+          "name": "employment_details_opportunity_id_opportunities_id_fk",
+          "tableFrom": "employment_details",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fellowship_details": {
+      "name": "fellowship_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "program_name": {
+          "name": "program_name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fellowship_type": {
+          "name": "fellowship_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "learning_outcomes": {
+          "name": "learning_outcomes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "program_structure": {
+          "name": "program_structure",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fellowship_details_opportunity_id_idx": {
+          "name": "fellowship_details_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fellowship_details_opportunity_id_opportunities_id_fk": {
+          "name": "fellowship_details_opportunity_id_opportunities_id_fk",
+          "tableFrom": "fellowship_details",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunities": {
+      "name": "opportunities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "opportunity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "opportunity_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'remote'"
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_deadline": {
+          "name": "application_deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eligibility_criteria": {
+          "name": "eligibility_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_questions": {
+          "name": "custom_questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opportunities_type_idx": {
+          "name": "opportunities_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_status_idx": {
+          "name": "opportunities_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_category_id_idx": {
+          "name": "opportunities_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunities_created_by_idx": {
+          "name": "opportunities_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunities_category_id_project_categories_id_fk": {
+          "name": "opportunities_category_id_project_categories_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "project_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opportunities_created_by_users_id_fk": {
+          "name": "opportunities_created_by_users_id_fk",
+          "tableFrom": "opportunities",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eligibility_rules": {
+      "name": "eligibility_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reject_message": {
+          "name": "reject_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eligibility_rules_opportunity_id_idx": {
+          "name": "eligibility_rules_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eligibility_rules_opportunity_id_opportunities_id_fk": {
+          "name": "eligibility_rules_opportunity_id_opportunities_id_fk",
+          "tableFrom": "eligibility_rules",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opportunity_forms": {
+      "name": "opportunity_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opportunity_forms_opp_version": {
+          "name": "opportunity_forms_opp_version",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opportunity_forms_opp_status_idx": {
+          "name": "opportunity_forms_opp_status_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opportunity_forms_opportunity_id_opportunities_id_fk": {
+          "name": "opportunity_forms_opportunity_id_opportunities_id_fk",
+          "tableFrom": "opportunity_forms",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "opportunity_forms_created_by_users_id_fk": {
+          "name": "opportunity_forms_created_by_users_id_fk",
+          "tableFrom": "opportunity_forms",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_scores": {
+      "name": "application_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "criterion_id": {
+          "name": "criterion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewer_user_id": {
+          "name": "reviewer_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_score_uniq": {
+          "name": "app_score_uniq",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "criterion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reviewer_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_scores_application_id_applications_id_fk": {
+          "name": "application_scores_application_id_applications_id_fk",
+          "tableFrom": "application_scores",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_scores_criterion_id_evaluation_criteria_id_fk": {
+          "name": "application_scores_criterion_id_evaluation_criteria_id_fk",
+          "tableFrom": "application_scores",
+          "tableTo": "evaluation_criteria",
+          "columnsFrom": ["criterion_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_scores_reviewer_user_id_users_id_fk": {
+          "name": "application_scores_reviewer_user_id_users_id_fk",
+          "tableFrom": "application_scores",
+          "tableTo": "users",
+          "columnsFrom": ["reviewer_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.application_stage_events": {
+      "name": "application_stage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_stage": {
+          "name": "from_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_stage": {
+          "name": "to_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stage_events_app_idx": {
+          "name": "stage_events_app_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_stage_events_application_id_applications_id_fk": {
+          "name": "application_stage_events_application_id_applications_id_fk",
+          "tableFrom": "application_stage_events",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_stage_events_actor_user_id_users_id_fk": {
+          "name": "application_stage_events_actor_user_id_users_id_fk",
+          "tableFrom": "application_stage_events",
+          "tableTo": "users",
+          "columnsFrom": ["actor_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.evaluation_criteria": {
+      "name": "evaluation_criteria",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "evaluation_criteria_opportunity_id_idx": {
+          "name": "evaluation_criteria_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "evaluation_criteria_opportunity_id_opportunities_id_fk": {
+          "name": "evaluation_criteria_opportunity_id_opportunities_id_fk",
+          "tableFrom": "evaluation_criteria",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recruitment_emails": {
+      "name": "recruitment_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_type": {
+          "name": "email_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "recruitment_email_once": {
+          "name": "recruitment_email_once",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recruitment_emails_application_id_applications_id_fk": {
+          "name": "recruitment_emails_application_id_applications_id_fk",
+          "tableFrom": "recruitment_emails",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.screening_rules": {
+      "name": "screening_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "opportunity_id": {
+          "name": "opportunity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_key": {
+          "name": "field_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_template": {
+          "name": "email_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "hit_count": {
+          "name": "hit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "screening_rules_opportunity_id_idx": {
+          "name": "screening_rules_opportunity_id_idx",
+          "columns": [
+            {
+              "expression": "opportunity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "screening_rules_opportunity_id_opportunities_id_fk": {
+          "name": "screening_rules_opportunity_id_opportunities_id_fk",
+          "tableFrom": "screening_rules",
+          "tableTo": "opportunities",
+          "columnsFrom": ["opportunity_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.application_status": {
+      "name": "application_status",
+      "schema": "public",
+      "values": [
+        "submitted",
+        "under_review",
+        "shortlisted",
+        "interviewed",
+        "accepted",
+        "rejected",
+        "waitlisted",
+        "withdrawn"
+      ]
+    },
+    "public.attendee_status": {
+      "name": "attendee_status",
+      "schema": "public",
+      "values": ["registered", "attended", "cancelled"]
+    },
+    "public.content_status": {
+      "name": "content_status",
+      "schema": "public",
+      "values": ["draft", "published", "archived"]
+    },
+    "public.context_type": {
+      "name": "context_type",
+      "schema": "public",
+      "values": ["project", "department", "personal_development", "other"]
+    },
+    "public.document_type": {
+      "name": "document_type",
+      "schema": "public",
+      "values": ["cv", "cover_letter", "certificate", "other"]
+    },
+    "public.education_level": {
+      "name": "education_level",
+      "schema": "public",
+      "values": [
+        "high_school",
+        "associate_degree",
+        "bachelors_degree",
+        "masters_degree",
+        "doctorate",
+        "professional_certification",
+        "other"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": ["public", "internal", "training"]
+    },
+    "public.gender": {
+      "name": "gender",
+      "schema": "public",
+      "values": ["male", "female", "non_binary", "prefer_not_to_say", "other"]
+    },
+    "public.job_posting_type": {
+      "name": "job_posting_type",
+      "schema": "public",
+      "values": ["internal", "external", "partner"]
+    },
+    "public.job_type": {
+      "name": "job_type",
+      "schema": "public",
+      "values": ["fellowship", "employment"]
+    },
+    "public.media_tag": {
+      "name": "media_tag",
+      "schema": "public",
+      "values": ["feature", "description", "others"]
+    },
+    "public.media_type": {
+      "name": "media_type",
+      "schema": "public",
+      "values": ["image", "video"]
+    },
+    "public.mentorship_status": {
+      "name": "mentorship_status",
+      "schema": "public",
+      "values": ["active", "completed", "paused"]
+    },
+    "public.mentorship_type": {
+      "name": "mentorship_type",
+      "schema": "public",
+      "values": ["fellow_mentor", "peer_mentor", "alumni_mentor"]
+    },
+    "public.news_category": {
+      "name": "news_category",
+      "schema": "public",
+      "values": ["all", "news", "blogs", "reports", "publications"]
+    },
+    "public.news_status": {
+      "name": "news_status",
+      "schema": "public",
+      "values": ["published", "not_published"]
+    },
+    "public.opportunity_status": {
+      "name": "opportunity_status",
+      "schema": "public",
+      "values": ["draft", "published", "closed", "cancelled"]
+    },
+    "public.opportunity_type": {
+      "name": "opportunity_type",
+      "schema": "public",
+      "values": ["fellowship", "employment"]
+    },
+    "public.posting_status": {
+      "name": "posting_status",
+      "schema": "public",
+      "values": ["draft", "published", "closed"]
+    },
+    "public.project_member_role": {
+      "name": "project_member_role",
+      "schema": "public",
+      "values": ["lead", "member", "supervisor", "contributor"]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": ["planned", "active", "completed", "cancelled", "on_hold", "overdue"]
+    },
+    "public.resource_access": {
+      "name": "resource_access",
+      "schema": "public",
+      "values": ["public", "fellow", "employee", "alumni"]
+    },
+    "public.resource_type": {
+      "name": "resource_type",
+      "schema": "public",
+      "values": ["document", "video", "guide", "research"]
+    },
+    "public.task_project_status": {
+      "name": "task_project_status",
+      "schema": "public",
+      "values": ["planning", "active", "on_hold", "completed", "cancelled"]
+    },
+    "public.task_team_role": {
+      "name": "task_team_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "viewer"]
+    },
+    "public.task_team_status": {
+      "name": "task_team_status",
+      "schema": "public",
+      "values": ["active", "inactive", "archived"]
+    },
+    "public.two_factor_method": {
+      "name": "two_factor_method",
+      "schema": "public",
+      "values": ["authenticator", "sms", "email"]
+    },
+    "public.verification_type": {
+      "name": "verification_type",
+      "schema": "public",
+      "values": ["email", "phone"]
+    },
+    "public.asset_issue": {
+      "name": "asset_issue",
+      "schema": "public",
+      "values": ["YES", "NO"]
+    },
+    "public.asset_status": {
+      "name": "asset_status",
+      "schema": "public",
+      "values": ["AVAILABLE", "ASSIGNED", "UNDER_MAINTENANCE", "DISPOSED"]
+    },
+    "public.contract_status": {
+      "name": "contract_status",
+      "schema": "public",
+      "values": ["ACTIVE", "EXPIRED", "TERMINATED"]
+    },
+    "public.contract_type": {
+      "name": "contract_type",
+      "schema": "public",
+      "values": ["FULL_TIME", "PART_TIME", "CONTRACT", "INTERNSHIP"]
+    },
+    "public.policy_category": {
+      "name": "policy_category",
+      "schema": "public",
+      "values": [
+        "Contract Templates",
+        "Policies & Procedures",
+        "Forms & Applications",
+        "Training Materials",
+        "Compliance & Legal",
+        "Onboarding Materials"
+      ]
+    },
+    "public.policy_status": {
+      "name": "policy_status",
+      "schema": "public",
+      "values": ["PUBLISHED", "DRAFT"]
+    },
+    "public.hr_role": {
+      "name": "hr_role",
+      "schema": "public",
+      "values": ["EMPLOYEE", "IT", "HR"]
+    },
+    "public.leave_status": {
+      "name": "leave_status",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED", "CANCELLED"]
+    },
+    "public.leave_type": {
+      "name": "leave_type",
+      "schema": "public",
+      "values": ["ANNUAL", "SICK", "MATERNITY", "PATERNITY", "UNPAID", "OTHER"]
+    },
+    "public.maintenance_status": {
+      "name": "maintenance_status",
+      "schema": "public",
+      "values": ["PENDING", "APPROVED", "REJECTED"]
+    },
+    "public.notification_priority": {
+      "name": "notification_priority",
+      "schema": "public",
+      "values": ["LOW", "NORMAL", "HIGH", "CRITICAL"]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": ["UNREAD", "READ", "ARCHIVED"]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "EMPLOYEE_CREATED",
+        "EMPLOYEE_STATUS_CHANGED",
+        "CONTRACT_CREATED",
+        "CONTRACT_UPDATED",
+        "CONTRACT_EXPIRING",
+        "LEAVE_REQUESTED",
+        "LEAVE_APPROVED",
+        "LEAVE_REJECTED",
+        "LEAVE_CANCELLED",
+        "TICKET_CREATED",
+        "TICKET_STATUS_CHANGED",
+        "TICKET_ASSIGNED",
+        "ASSET_ASSIGNED",
+        "ASSET_RETURNED",
+        "ASSET_STATUS_CHANGED",
+        "DOCUMENT_PUBLISHED"
+      ]
+    },
+    "public.hr_policy_category": {
+      "name": "hr_policy_category",
+      "schema": "public",
+      "values": ["GENERAL", "HR", "IT", "FINANCE", "COMPLIANCE", "OTHER"]
+    },
+    "public.hr_policy_status": {
+      "name": "hr_policy_status",
+      "schema": "public",
+      "values": ["PUBLISHED", "DRAFT"]
+    },
+    "public.ticket_priority": {
+      "name": "ticket_priority",
+      "schema": "public",
+      "values": ["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": ["OPEN", "IN_PROGRESS", "RESOLVED", "CLOSED"]
+    },
+    "public.user_status": {
+      "name": "user_status",
+      "schema": "public",
+      "values": ["ACTIVE", "ON_LEAVE", "INACTIVE", "TERMINATED"]
+    },
+    "public.task_priority": {
+      "name": "task_priority",
+      "schema": "public",
+      "values": ["low", "medium", "high"]
+    },
+    "public.task_status": {
+      "name": "task_status",
+      "schema": "public",
+      "values": ["overdue", "todo", "inprogress", "review", "done"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784541622734,
       "tag": "0004_recruitment_forms_and_eligibility",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784632007220,
+      "tag": "0005_recruitment_pipeline",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:db:up": "tsx scripts/test-db.ts up",
     "test:db:down": "tsx scripts/test-db.ts down"
@@ -44,6 +45,7 @@
     "drizzle-orm": "^0.39.3",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
+    "express-rate-limit": "^7.4.1",
     "googleapis": "^166.0.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
@@ -62,8 +64,7 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",
     "uuid": "^9.0.1",
-    "zod": "^3.24.2",
-    "express-rate-limit": "^7.4.1"
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -81,6 +82,7 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.6",
     "@types/uuid": "^9.0.8",
+    "@vitest/coverage-v8": "3",
     "@workspace/eslint-config": "workspace:*",
     "cross-env": "^10.1.0",
     "eslint": "^9.15.0",

--- a/backend/scripts/seed-recruitment-demo.ts
+++ b/backend/scripts/seed-recruitment-demo.ts
@@ -1,0 +1,184 @@
+/**
+ * REC-02 demo seed: one opportunity with a published form, eligibility + screening rules,
+ * evaluation criteria, and 12 applications spread across pipeline stages — so REC-03 UI work has
+ * a realistic pipeline immediately. Idempotent-ish: creates a fresh opportunity each run.
+ *
+ * Usage: DATABASE_URL=... tsx scripts/seed-recruitment-demo.ts
+ */
+import { db } from "../src/db/client";
+import {
+  users,
+  opportunities,
+  opportunity_forms,
+  eligibility_rules,
+  applications,
+  application_stage_events,
+  screening_rules,
+  evaluation_criteria,
+} from "../src/db/schema";
+import { eq } from "drizzle-orm";
+import type { FormDefinition } from "../src/types/recruitment";
+
+const STAGES = [
+  "submitted",
+  "submitted",
+  "screening",
+  "screening",
+  "shortlisted",
+  "shortlisted",
+  "interview",
+  "interview",
+  "evaluation",
+  "offer",
+  "rejected",
+  "withdrawn",
+] as const;
+
+async function main() {
+  const [creator] = await db.select({ id: users.id }).from(users).limit(1);
+  if (!creator) throw new Error("Seed needs at least one user — run the RBAC/user seed first.");
+
+  const [opp] = await db
+    .insert(opportunities)
+    .values({
+      title: "Demo Fellowship — Recruitment Pipeline",
+      description: "Seeded opportunity for recruitment pipeline UI development (REC-02).",
+      type: "fellowship",
+      status: "published",
+      application_deadline: "2099-12-31",
+      created_by: creator.id,
+    })
+    .returning();
+
+  const definition: FormDefinition = {
+    standard: [
+      {
+        key: "first_name",
+        label: "First name",
+        type: "text",
+        required: true,
+        order: 1,
+        section: "About you",
+      },
+      {
+        key: "last_name",
+        label: "Last name",
+        type: "text",
+        required: true,
+        order: 2,
+        section: "About you",
+      },
+      {
+        key: "email",
+        label: "Email",
+        type: "text",
+        required: true,
+        order: 3,
+        section: "About you",
+      },
+      {
+        key: "date_of_birth",
+        label: "Date of birth",
+        type: "date",
+        required: true,
+        order: 4,
+        section: "About you",
+      },
+    ],
+    custom: [
+      {
+        key: "degree",
+        label: "Highest degree",
+        type: "select",
+        required: true,
+        order: 5,
+        section: "Background",
+        options: ["none", "bsc", "msc", "phd"],
+      },
+    ],
+  };
+  await db.insert(opportunity_forms).values({
+    opportunity_id: opp.id,
+    version: 1,
+    status: "published",
+    definition,
+    created_by: creator.id,
+  });
+
+  await db.insert(eligibility_rules).values({
+    opportunity_id: opp.id,
+    field_key: "age",
+    operator: "gt",
+    value: 35,
+    reject_message: "This fellowship is for applicants aged 35 or under.",
+  });
+
+  await db.insert(screening_rules).values({
+    opportunity_id: opp.id,
+    field_key: "degree",
+    operator: "eq",
+    value: "none",
+    action: "auto_reject",
+    email_template: "rejected",
+    rejection_reason: "A completed degree is required for this fellowship.",
+  });
+
+  await db.insert(evaluation_criteria).values([
+    { opportunity_id: opp.id, name: "Motivation", weight: "2", max_score: 5, sort_order: 1 },
+    { opportunity_id: opp.id, name: "Experience", weight: "1", max_score: 5, sort_order: 2 },
+    { opportunity_id: opp.id, name: "Communication", weight: "1", max_score: 5, sort_order: 3 },
+  ]);
+
+  for (let i = 0; i < STAGES.length; i++) {
+    const stage = STAGES[i];
+    const [app] = await db
+      .insert(applications)
+      .values({
+        opportunity_id: opp.id,
+        first_name: `Demo${i + 1}`,
+        last_name: "Applicant",
+        email: `demo_${i + 1}_${Date.now()}@example.com`,
+        phone: "+250700000000",
+        national_id: `DEMO${i + 1}`,
+        city: "Kigali",
+        country: "Rwanda",
+        education_level: "bachelors_degree",
+        field_of_study: "Agriculture",
+        career_experience: "2 years",
+        cv_url: "https://files.example.com/cv.pdf",
+        motivation: "Motivated demo applicant.",
+        five_year_vision: "Vision.",
+        desired_impact: "Impact.",
+        community_role: "Role.",
+        national_strategy: "Strategy.",
+        how_ganzafrica_can_help: "Help.",
+        contribution_to_ganzafrica: "Contribution.",
+        data_processing_consent: true,
+        date_of_birth: "1998-06-15",
+        pipeline_stage: stage,
+        form_version: 1,
+      })
+      .returning();
+
+    await db.insert(application_stage_events).values({
+      application_id: app.id,
+      from_stage: "submitted",
+      to_stage: stage,
+      actor_user_id: stage === "rejected" ? null : creator.id,
+      note: "Seeded",
+    });
+  }
+
+  const count = await db
+    .select({ id: applications.id })
+    .from(applications)
+    .where(eq(applications.opportunity_id, opp.id));
+  console.log(`Seeded opportunity #${opp.id} with ${count.length} applications across stages.`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("seed-recruitment-demo failed:", err);
+    process.exit(1);
+  });

--- a/backend/src/controllers/recruitment-pipeline.ts
+++ b/backend/src/controllers/recruitment-pipeline.ts
@@ -1,0 +1,158 @@
+import { Request, Response } from "express";
+import * as pipeline from "../services/recruitment/pipeline.service";
+import { AppError } from "../middlewares";
+import { constants, Logger } from "../config";
+
+const logger = new Logger("RecruitmentPipelineController");
+
+function handleError(res: Response, error: unknown, context: string) {
+  if (error instanceof pipeline.IllegalTransitionError) {
+    return res.status(409).json({ error: "Illegal transition", allowed: error.allowed });
+  }
+  logger.error(context, error as Error);
+  if (error instanceof AppError) {
+    return res.status(error.statusCode).json({ error: context, message: error.message });
+  }
+  return res
+    .status(500)
+    .json({ error: context, message: constants.ERROR_MESSAGES.INTERNAL_SERVER_ERROR });
+}
+
+export const listOpportunities = async (_req: Request, res: Response) => {
+  try {
+    const opportunities = await pipeline.listOpportunitiesWithStageCounts();
+    return res.json({ opportunities });
+  } catch (error) {
+    return handleError(res, error, "List Opportunities Error");
+  }
+};
+
+export const listApplications = async (req: Request, res: Response) => {
+  try {
+    const result = await pipeline.listApplications({
+      opportunity_id: req.query.opportunity_id ? Number(req.query.opportunity_id) : undefined,
+      stage: req.query.stage as string | undefined,
+      flagged: req.query.flagged === undefined ? undefined : req.query.flagged === "true",
+      search: req.query.search as string | undefined,
+      page: req.query.page ? Number(req.query.page) : undefined,
+    });
+    return res.json(result);
+  } catch (error) {
+    return handleError(res, error, "List Applications Error");
+  }
+};
+
+export const getApplication = async (req: Request, res: Response) => {
+  try {
+    const detail = await pipeline.getApplicationDetail(Number(req.params.id));
+    return res.json(detail);
+  } catch (error) {
+    return handleError(res, error, "Get Application Error");
+  }
+};
+
+export const transition = async (req: Request, res: Response) => {
+  try {
+    const actorId = Number(req.user!.id);
+    const app = await pipeline.transition(Number(req.params.id), req.body.to_stage, actorId, {
+      note: req.body.note,
+      sendEmailToApplicant: Boolean(req.body.send_email),
+    });
+    return res.json({ application: app });
+  } catch (error) {
+    return handleError(res, error, "Transition Error");
+  }
+};
+
+export const rescreen = async (req: Request, res: Response) => {
+  try {
+    await pipeline.runScreening(Number(req.params.id));
+    const detail = await pipeline.getApplicationDetail(Number(req.params.id));
+    return res.json(detail);
+  } catch (error) {
+    return handleError(res, error, "Rescreen Error");
+  }
+};
+
+// Screening rules
+export const listScreeningRules = async (req: Request, res: Response) => {
+  try {
+    return res.json({ rules: await pipeline.listScreeningRules(Number(req.params.id)) });
+  } catch (error) {
+    return handleError(res, error, "List Screening Rules Error");
+  }
+};
+export const createScreeningRule = async (req: Request, res: Response) => {
+  try {
+    return res
+      .status(201)
+      .json({ rule: await pipeline.createScreeningRule(Number(req.params.id), req.body) });
+  } catch (error) {
+    return handleError(res, error, "Create Screening Rule Error");
+  }
+};
+export const patchScreeningRule = async (req: Request, res: Response) => {
+  try {
+    return res.json({
+      rule: await pipeline.updateScreeningRule(Number(req.params.ruleId), req.body),
+    });
+  } catch (error) {
+    return handleError(res, error, "Update Screening Rule Error");
+  }
+};
+export const deleteScreeningRule = async (req: Request, res: Response) => {
+  try {
+    return res.json(await pipeline.deleteScreeningRule(Number(req.params.ruleId)));
+  } catch (error) {
+    return handleError(res, error, "Delete Screening Rule Error");
+  }
+};
+
+// Evaluation criteria
+export const listCriteria = async (req: Request, res: Response) => {
+  try {
+    return res.json({ criteria: await pipeline.listCriteria(Number(req.params.id)) });
+  } catch (error) {
+    return handleError(res, error, "List Criteria Error");
+  }
+};
+export const createCriterion = async (req: Request, res: Response) => {
+  try {
+    return res
+      .status(201)
+      .json({ criterion: await pipeline.createCriterion(Number(req.params.id), req.body) });
+  } catch (error) {
+    return handleError(res, error, "Create Criterion Error");
+  }
+};
+export const patchCriterion = async (req: Request, res: Response) => {
+  try {
+    return res.json({
+      criterion: await pipeline.updateCriterion(Number(req.params.criterionId), req.body),
+    });
+  } catch (error) {
+    return handleError(res, error, "Update Criterion Error");
+  }
+};
+export const deleteCriterion = async (req: Request, res: Response) => {
+  try {
+    return res.json(await pipeline.deleteCriterion(Number(req.params.criterionId)));
+  } catch (error) {
+    return handleError(res, error, "Delete Criterion Error");
+  }
+};
+
+// Scores
+export const putScores = async (req: Request, res: Response) => {
+  try {
+    const reviewerId = Number(req.user!.id);
+    const weightedTotal = await pipeline.upsertScores(
+      Number(req.params.id),
+      reviewerId,
+      req.body.scores,
+    );
+    return res.json({ weighted_total: weightedTotal });
+  } catch (error) {
+    return handleError(res, error, "Save Scores Error");
+  }
+};

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -19,3 +19,4 @@ export * from "./payslip-tokens";
 export * from "./opportunities";
 export * from "./hr/index";
 export * from "./recruitment/forms";
+export * from "./recruitment/pipeline";

--- a/backend/src/db/schema/opportunities.ts
+++ b/backend/src/db/schema/opportunities.ts
@@ -183,6 +183,13 @@ export const applications = pgTable(
     country_of_work: text("country_of_work"),
     has_work_permit: boolean("has_work_permit"),
 
+    // REC-02: pipeline_stage is the recruitment pipeline's truth; legacy `status` below is kept
+    // coherent by a service-level sync map. Nullable/defaulted so existing rows are untouched.
+    pipeline_stage: text("pipeline_stage").notNull().default("submitted"),
+    rejection_reason: text("rejection_reason"),
+    flagged: boolean("flagged").notNull().default(false),
+    flag_note: text("flag_note"),
+
     // Application status and tracking
     status: applicationStatusEnum("status").notNull().default("submitted"),
     submission_date: timestamp("submission_date", { withTimezone: true }).notNull().defaultNow(),

--- a/backend/src/db/schema/recruitment/pipeline.ts
+++ b/backend/src/db/schema/recruitment/pipeline.ts
@@ -1,0 +1,126 @@
+import {
+  integer,
+  pgTable,
+  text,
+  jsonb,
+  serial,
+  boolean,
+  numeric,
+  timestamp,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+import { timestampFields } from "../common";
+import { users } from "../users";
+import { opportunities, applications } from "../opportunities";
+
+// Ordered pipeline stages (REC-02). pipeline_stage on applications is the pipeline's truth; the
+// legacy applicationStatusEnum is kept coherent by a service-level sync map (see pipeline.service).
+export const PIPELINE_STAGES = [
+  "submitted",
+  "screening",
+  "shortlisted",
+  "interview",
+  "evaluation",
+  "offer",
+  "hired",
+  "rejected",
+  "withdrawn",
+] as const;
+
+export type PipelineStage = (typeof PIPELINE_STAGES)[number];
+
+// Append-only audit trail of every stage change (actor NULL = automation, e.g. auto-reject).
+export const application_stage_events = pgTable(
+  "application_stage_events",
+  {
+    id: serial("id").primaryKey(),
+    application_id: integer("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    from_stage: text("from_stage"),
+    to_stage: text("to_stage").notNull(),
+    actor_user_id: integer("actor_user_id").references(() => users.id),
+    note: text("note"),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({ appIdx: index("stage_events_app_idx").on(t.application_id) }),
+);
+
+// Post-submission screening rules (REC-02). Same operator vocabulary as REC-01 eligibility rules,
+// but the action auto-rejects or flags an already-created application. Runs AFTER insert; a
+// screening error must never fail the submission.
+export const screening_rules = pgTable(
+  "screening_rules",
+  {
+    id: serial("id").primaryKey(),
+    opportunity_id: integer("opportunity_id")
+      .notNull()
+      .references(() => opportunities.id, { onDelete: "cascade" }),
+    field_key: text("field_key").notNull(),
+    operator: text("operator").notNull(),
+    value: jsonb("value"),
+    action: text("action").notNull(), // 'auto_reject' | 'flag'
+    email_template: text("email_template"), // template key for auto_reject (null = silent reject)
+    rejection_reason: text("rejection_reason"),
+    is_active: boolean("is_active").notNull().default(true),
+    hit_count: integer("hit_count").notNull().default(0),
+    ...timestampFields,
+  },
+  (t) => ({ oppIdx: index("screening_rules_opportunity_id_idx").on(t.opportunity_id) }),
+);
+
+// Weighted evaluation criteria per opportunity.
+export const evaluation_criteria = pgTable(
+  "evaluation_criteria",
+  {
+    id: serial("id").primaryKey(),
+    opportunity_id: integer("opportunity_id")
+      .notNull()
+      .references(() => opportunities.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    weight: numeric("weight", { precision: 5, scale: 2 }).notNull().default("1"),
+    max_score: integer("max_score").notNull().default(5),
+    sort_order: integer("sort_order").notNull().default(0),
+    ...timestampFields,
+  },
+  (t) => ({ oppIdx: index("evaluation_criteria_opportunity_id_idx").on(t.opportunity_id) }),
+);
+
+// Per-reviewer, per-criterion scores. One row per (application, criterion, reviewer).
+export const application_scores = pgTable(
+  "application_scores",
+  {
+    id: serial("id").primaryKey(),
+    application_id: integer("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    criterion_id: integer("criterion_id")
+      .notNull()
+      .references(() => evaluation_criteria.id, { onDelete: "cascade" }),
+    reviewer_user_id: integer("reviewer_user_id")
+      .notNull()
+      .references(() => users.id),
+    score: integer("score").notNull(), // 0..criterion.max_score, service-validated
+    comment: text("comment"),
+    ...timestampFields,
+  },
+  (t) => ({
+    uniq: uniqueIndex("app_score_uniq").on(t.application_id, t.criterion_id, t.reviewer_user_id),
+  }),
+);
+
+// Idempotent record of applicant emails: one row per (application, email_type). The unique index
+// is the idempotency guard — insert-first, unique-violation => already sent, skip.
+export const recruitment_emails = pgTable(
+  "recruitment_emails",
+  {
+    id: serial("id").primaryKey(),
+    application_id: integer("application_id")
+      .notNull()
+      .references(() => applications.id, { onDelete: "cascade" }),
+    email_type: text("email_type").notNull(), // 'received'|'rejected'|'shortlisted'|'interview'|'offer'|'hired'
+    sent_at: timestamp("sent_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({ uniq: uniqueIndex("recruitment_email_once").on(t.application_id, t.email_type) }),
+);

--- a/backend/src/routes/hr/recruitment.routes.ts
+++ b/backend/src/routes/hr/recruitment.routes.ts
@@ -3,6 +3,8 @@ import { authenticate, requirePermission } from "@/middlewares/auth.middleware";
 import { validate } from "@/middlewares/validation.middleware";
 import * as recruitmentController from "@/controllers/recruitment";
 import * as recruitmentValidation from "@/validations/recruitment";
+import * as pipelineController from "@/controllers/recruitment-pipeline";
+import * as pipelineValidation from "@/validations/recruitment-pipeline";
 
 const router: Router = Router();
 
@@ -16,6 +18,8 @@ const router: Router = Router();
 // authenticate is applied per-route (not router-wide) so this router only claims its own paths
 // and never intercepts sibling /hr/* routes mounted alongside it.
 const guard = [authenticate, requirePermission("recruitment:manage")];
+// Read-level guard (HR + director). Lists are readable; mutations stay manage-only.
+const readGuard = [authenticate, requirePermission("recruitment:read", "recruitment:manage")];
 
 // Form builder (draft read/write + publish).
 router.get(
@@ -66,6 +70,91 @@ router.delete(
   ...guard,
   validate(recruitmentValidation.deleteRuleSchema),
   recruitmentController.deleteRule,
+);
+
+// --- REC-02 pipeline ---
+
+// Lists readable by director (recruitment:read); everything else is manage-only.
+router.get("/recruitment/opportunities", ...readGuard, pipelineController.listOpportunities);
+router.get("/recruitment/applications", ...readGuard, pipelineController.listApplications);
+router.get(
+  "/recruitment/applications/:id",
+  ...readGuard,
+  validate(pipelineValidation.idParamSchema),
+  pipelineController.getApplication,
+);
+
+router.post(
+  "/recruitment/applications/:id/transition",
+  ...guard,
+  validate(pipelineValidation.transitionSchema),
+  pipelineController.transition,
+);
+router.post(
+  "/recruitment/applications/:id/rescreen",
+  ...guard,
+  validate(pipelineValidation.idParamSchema),
+  pipelineController.rescreen,
+);
+
+// Screening rules CRUD.
+router.get(
+  "/recruitment/opportunities/:id/screening-rules",
+  ...guard,
+  validate(pipelineValidation.idParamSchema),
+  pipelineController.listScreeningRules,
+);
+router.post(
+  "/recruitment/opportunities/:id/screening-rules",
+  ...guard,
+  validate(pipelineValidation.createScreeningRuleSchema),
+  pipelineController.createScreeningRule,
+);
+router.patch(
+  "/recruitment/opportunities/:id/screening-rules/:ruleId",
+  ...guard,
+  validate(pipelineValidation.patchScreeningRuleSchema),
+  pipelineController.patchScreeningRule,
+);
+router.delete(
+  "/recruitment/opportunities/:id/screening-rules/:ruleId",
+  ...guard,
+  validate(pipelineValidation.screeningRuleIdSchema),
+  pipelineController.deleteScreeningRule,
+);
+
+// Evaluation criteria CRUD.
+router.get(
+  "/recruitment/opportunities/:id/criteria",
+  ...guard,
+  validate(pipelineValidation.idParamSchema),
+  pipelineController.listCriteria,
+);
+router.post(
+  "/recruitment/opportunities/:id/criteria",
+  ...guard,
+  validate(pipelineValidation.createCriterionSchema),
+  pipelineController.createCriterion,
+);
+router.patch(
+  "/recruitment/opportunities/:id/criteria/:criterionId",
+  ...guard,
+  validate(pipelineValidation.patchCriterionSchema),
+  pipelineController.patchCriterion,
+);
+router.delete(
+  "/recruitment/opportunities/:id/criteria/:criterionId",
+  ...guard,
+  validate(pipelineValidation.criterionIdSchema),
+  pipelineController.deleteCriterion,
+);
+
+// Reviewers (recruitment:read) upsert their OWN scores; the service keys on reviewer id.
+router.put(
+  "/recruitment/applications/:id/scores",
+  ...readGuard,
+  validate(pipelineValidation.putScoresSchema),
+  pipelineController.putScores,
 );
 
 export default router;

--- a/backend/src/services/opportunity.ts
+++ b/backend/src/services/opportunity.ts
@@ -12,6 +12,7 @@ import { Logger } from "../config";
 import { v4 as uuidv4 } from "uuid";
 import { evaluate, recordHits } from "./recruitment/eligibility.service";
 import { getActiveRules, getPublishedForm } from "./recruitment/forms.service";
+import { runScreening, sendApplicantEmail } from "./recruitment/pipeline.service";
 
 const logger = new Logger("OpportunityService");
 
@@ -717,6 +718,23 @@ export async function submitApplication(applicationData: ApplicationInput): Prom
         updated_at: new Date(),
       })
       .returning();
+
+    // REC-02: post-insert screening (auto-reject/flag) then the acknowledgment email. Screening is
+    // non-fatal (it can never fail the submission). Skip "received" if screening auto-rejected —
+    // the rejection email already went out.
+    if (createdApplication?.id) {
+      await runScreening(createdApplication.id);
+      const [screened] = await db
+        .select({ stage: applications.pipeline_stage })
+        .from(applications)
+        .where(eq(applications.id, createdApplication.id))
+        .limit(1);
+      if (screened?.stage !== "rejected") {
+        await sendApplicantEmail(createdApplication.id, "received").catch((err) =>
+          logger.error("received email failed (non-fatal)", err),
+        );
+      }
+    }
 
     return createdApplication;
   } catch (error) {

--- a/backend/src/services/recruitment/email-templates.ts
+++ b/backend/src/services/recruitment/email-templates.ts
@@ -1,0 +1,101 @@
+/**
+ * GanzAfrica-branded applicant email templates (REC-02). Plain inline HTML like the payslip mails.
+ * Each returns { subject, html }. `rejected` uses the HR-authored rejection_reason copy only —
+ * never rule internals (GDPR-ish, spec §8).
+ */
+
+export type ApplicantEmailType =
+  | "received"
+  | "rejected"
+  | "shortlisted"
+  | "interview"
+  | "offer"
+  | "hired";
+
+interface TemplateInput {
+  firstName: string;
+  opportunityTitle: string;
+  rejectionReason?: string | null;
+}
+
+function shell(bodyHtml: string): string {
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+<body style="margin:0;font-family:Arial,sans-serif;background:#f9f9f9;">
+  <div style="max-width:600px;margin:0 auto;">
+    <div style="background:#045F3C;padding:20px;text-align:center;">
+      <h1 style="color:#fff;margin:0;">GanzAfrica</h1>
+    </div>
+    <div style="padding:32px 30px;color:#333;line-height:1.6;">
+      ${bodyHtml}
+      <p style="margin-top:28px;color:#555;">Warm regards,<br/>The GanzAfrica Recruitment Team</p>
+    </div>
+  </div>
+</body></html>`;
+}
+
+const TEMPLATES: Record<
+  ApplicantEmailType,
+  (i: TemplateInput) => { subject: string; html: string }
+> = {
+  received: (i) => ({
+    subject: `We received your application — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>Thank you for applying for <strong>${i.opportunityTitle}</strong>. We've received your
+       application and our team will review it carefully. We'll be in touch about next steps.</p>`,
+    ),
+  }),
+  rejected: (i) => ({
+    subject: `Update on your application — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>Thank you for your interest in <strong>${i.opportunityTitle}</strong> and for the time
+       you invested in your application.</p>
+       <p>${
+         i.rejectionReason?.trim()
+           ? i.rejectionReason
+           : "After careful consideration, we won't be moving forward with your application at this time."
+       }</p>
+       <p>We genuinely appreciate your interest in GanzAfrica and encourage you to apply for future
+       opportunities that match your profile.</p>`,
+    ),
+  }),
+  shortlisted: (i) => ({
+    subject: `Good news about your application — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>We're pleased to let you know that you've been <strong>shortlisted</strong> for
+       <strong>${i.opportunityTitle}</strong>. Our team will reach out shortly with the next steps.</p>`,
+    ),
+  }),
+  interview: (i) => ({
+    subject: `Interview invitation — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>Congratulations — we'd like to invite you to an <strong>interview</strong> for
+       <strong>${i.opportunityTitle}</strong>. A member of our team will contact you to arrange a
+       convenient time.</p>`,
+    ),
+  }),
+  offer: (i) => ({
+    subject: `An offer for you — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>We're delighted to extend an offer for <strong>${i.opportunityTitle}</strong>. Details
+       will follow separately.</p>`,
+    ),
+  }),
+  hired: (i) => ({
+    subject: `Welcome to GanzAfrica — ${i.opportunityTitle}`,
+    html: shell(
+      `<p>Hi ${i.firstName},</p>
+       <p>Welcome aboard! We're thrilled to have you join us for
+       <strong>${i.opportunityTitle}</strong>.</p>`,
+    ),
+  }),
+};
+
+export function renderApplicantEmail(type: ApplicantEmailType, input: TemplateInput) {
+  return TEMPLATES[type](input);
+}

--- a/backend/src/services/recruitment/pipeline.service.ts
+++ b/backend/src/services/recruitment/pipeline.service.ts
@@ -1,0 +1,646 @@
+/**
+ * Recruitment pipeline (REC-02): staged transitions with an audit trail, post-submission
+ * screening, idempotent applicant emails, and weighted evaluation scoring — all additive on the
+ * existing applications table.
+ */
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../../db/client";
+import { applications, opportunities } from "../../db/schema/opportunities";
+import {
+  application_scores,
+  application_stage_events,
+  evaluation_criteria,
+  recruitment_emails,
+  screening_rules,
+  PIPELINE_STAGES,
+  type PipelineStage,
+} from "../../db/schema/recruitment/pipeline";
+import { AppError } from "../../middlewares";
+import { Logger } from "../../config";
+import { evaluate } from "./eligibility.service";
+import type { EligibilityRuleInput } from "../../types/recruitment";
+import { renderApplicantEmail, type ApplicantEmailType } from "./email-templates";
+import { sendEmail } from "../email.service";
+
+const logger = new Logger("PipelineService");
+
+// Legal moves. Terminal stages (rejected/withdrawn/hired) go nowhere. withdrawn is reachable from
+// any non-terminal stage. offer/hired transitions are executed by REC-05 but validated here.
+export const ALLOWED_TRANSITIONS: Record<PipelineStage, PipelineStage[]> = {
+  submitted: ["screening", "rejected", "withdrawn"],
+  screening: ["shortlisted", "rejected", "withdrawn"],
+  shortlisted: ["interview", "rejected", "withdrawn"],
+  interview: ["evaluation", "rejected", "withdrawn"],
+  evaluation: ["offer", "rejected", "withdrawn"],
+  offer: ["hired", "rejected", "withdrawn"],
+  hired: [],
+  rejected: [],
+  withdrawn: [],
+};
+
+// pipeline_stage → legacy applicationStatusEnum, kept coherent so the portal's existing views
+// stay correct. Encoded as data + covered by a test (spec §6.7).
+export const LEGACY_STATUS_MAP: Record<PipelineStage, string> = {
+  submitted: "submitted",
+  screening: "under_review",
+  shortlisted: "shortlisted",
+  interview: "interviewed",
+  evaluation: "under_review",
+  offer: "shortlisted",
+  hired: "accepted",
+  rejected: "rejected",
+  withdrawn: "withdrawn",
+};
+
+// Which stages trigger an applicant email (when requested).
+const STAGE_EMAIL: Partial<Record<PipelineStage, ApplicantEmailType>> = {
+  submitted: "received",
+  shortlisted: "shortlisted",
+  interview: "interview",
+  rejected: "rejected",
+};
+
+export function isValidStage(stage: string): stage is PipelineStage {
+  return (PIPELINE_STAGES as readonly string[]).includes(stage);
+}
+
+export class IllegalTransitionError extends Error {
+  constructor(
+    public readonly from: string,
+    public readonly to: string,
+    public readonly allowed: PipelineStage[],
+  ) {
+    super(`Illegal transition ${from} → ${to}`);
+    this.name = "IllegalTransitionError";
+  }
+}
+
+type TransitionOpts = {
+  note?: string;
+  sendEmailToApplicant?: boolean;
+  rejectionReason?: string | null;
+};
+
+/**
+ * Move an application to `toStage`. Validates the matrix, then atomically updates the application
+ * (optimistic on the current stage) and writes a stage event, syncing legacy status. The applicant
+ * email is sent AFTER commit (non-blocking) so a mail failure never rolls back the move.
+ */
+export async function transition(
+  applicationId: number,
+  toStage: string,
+  actorUserId: number | null,
+  opts: TransitionOpts = {},
+) {
+  if (!isValidStage(toStage)) {
+    throw new AppError(`Unknown stage: ${toStage}`, 400);
+  }
+
+  const [app] = await db
+    .select()
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  if (!app) throw new AppError("Application not found", 404);
+
+  const fromStage = app.pipeline_stage as PipelineStage;
+  const allowed = ALLOWED_TRANSITIONS[fromStage] ?? [];
+  if (!allowed.includes(toStage)) {
+    throw new IllegalTransitionError(fromStage, toStage, allowed);
+  }
+
+  // Optimistic concurrency: only move if still in the observed stage. 0 rows → someone raced us.
+  const updated = await db
+    .update(applications)
+    .set({
+      pipeline_stage: toStage,
+      status: LEGACY_STATUS_MAP[toStage] as (typeof applications.status.enumValues)[number],
+      rejection_reason: opts.rejectionReason ?? app.rejection_reason,
+      updated_at: new Date(),
+    })
+    .where(and(eq(applications.id, applicationId), eq(applications.pipeline_stage, fromStage)))
+    .returning();
+
+  if (updated.length === 0) {
+    // Re-read for the freshest allowed set.
+    const [fresh] = await db
+      .select({ stage: applications.pipeline_stage })
+      .from(applications)
+      .where(eq(applications.id, applicationId))
+      .limit(1);
+    const freshStage = (fresh?.stage ?? fromStage) as PipelineStage;
+    throw new IllegalTransitionError(freshStage, toStage, ALLOWED_TRANSITIONS[freshStage] ?? []);
+  }
+
+  await db.insert(application_stage_events).values({
+    application_id: applicationId,
+    from_stage: fromStage,
+    to_stage: toStage,
+    actor_user_id: actorUserId,
+    note: opts.note,
+  });
+
+  // Post-commit email — failure is logged, never surfaced as a transition failure.
+  if (opts.sendEmailToApplicant && STAGE_EMAIL[toStage]) {
+    try {
+      await sendApplicantEmail(applicationId, STAGE_EMAIL[toStage]!);
+    } catch (err) {
+      logger.error(`Stage email failed for application ${applicationId} (${toStage})`, err);
+    }
+  }
+
+  return updated[0];
+}
+
+/**
+ * Post-insert screening (REC-02). Evaluates active screening rules with the REC-01 engine; a `flag`
+ * sets flagged+flag_note, an `auto_reject` transitions to rejected (actor NULL) with the rule's
+ * rejection_reason and optional email. WRAPPED so a screening error never fails the submission.
+ */
+export async function runScreening(applicationId: number): Promise<void> {
+  try {
+    const [app] = await db
+      .select()
+      .from(applications)
+      .where(eq(applications.id, applicationId))
+      .limit(1);
+    if (!app || !app.opportunity_id) return;
+    // Only screen freshly-submitted applications.
+    if (app.pipeline_stage !== "submitted") return;
+
+    const rules = await db
+      .select()
+      .from(screening_rules)
+      .where(
+        and(
+          eq(screening_rules.opportunity_id, app.opportunity_id),
+          eq(screening_rules.is_active, true),
+        ),
+      );
+    if (rules.length === 0) return;
+
+    const answers: Record<string, unknown> = {
+      ...((app.custom_answers as Record<string, unknown>) || {}),
+      date_of_birth: app.date_of_birth,
+      country_of_residence: app.country_of_residence,
+      country_of_work: app.country_of_work,
+      has_work_permit: app.has_work_permit,
+    };
+
+    const engineRules: EligibilityRuleInput[] = rules.map((r) => ({
+      id: r.id,
+      field_key: r.field_key,
+      operator: r.operator,
+      value: r.value,
+      reject_message: "",
+    }));
+    const result = evaluate(engineRules, answers);
+    if (result.eligible) return;
+
+    const matchedIds = new Set(result.failedRuleIds);
+    const matched = rules.filter((r) => matchedIds.has(r.id));
+
+    // Record hits for every matched rule.
+    await db
+      .update(screening_rules)
+      .set({ hit_count: sql`${screening_rules.hit_count} + 1` })
+      .where(inArray(screening_rules.id, [...matchedIds]));
+
+    const autoReject = matched.find((r) => r.action === "auto_reject");
+    if (autoReject) {
+      await transition(applicationId, "rejected", null, {
+        note: "Auto-rejected by screening rule",
+        rejectionReason: autoReject.rejection_reason,
+        sendEmailToApplicant: Boolean(autoReject.email_template),
+      });
+      return;
+    }
+
+    // No auto-reject — apply flags.
+    const flagNotes = matched
+      .filter((r) => r.action === "flag")
+      .map((r) => r.rejection_reason || `Flagged by rule ${r.id}`);
+    if (flagNotes.length > 0) {
+      await db
+        .update(applications)
+        .set({ flagged: true, flag_note: flagNotes.join("; "), updated_at: new Date() })
+        .where(eq(applications.id, applicationId));
+    }
+  } catch (err) {
+    logger.error(`Screening failed for application ${applicationId} (non-fatal)`, err);
+  }
+}
+
+/**
+ * Send an applicant email exactly once per (application, type). Inserts the idempotency row first;
+ * a unique violation means it was already sent, so we skip. Only then does Resend fire.
+ */
+export async function sendApplicantEmail(
+  applicationId: number,
+  type: ApplicantEmailType,
+): Promise<{ sent: boolean }> {
+  try {
+    await db.insert(recruitment_emails).values({ application_id: applicationId, email_type: type });
+  } catch (err: unknown) {
+    if (isUniqueViolation(err)) return { sent: false };
+    throw err;
+  }
+
+  const [app] = await db
+    .select({
+      email: applications.email,
+      first_name: applications.first_name,
+      opportunity_id: applications.opportunity_id,
+    })
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  if (!app) return { sent: false };
+
+  let opportunityTitle = "your application";
+  if (app.opportunity_id) {
+    const [opp] = await db
+      .select({ title: opportunities.title })
+      .from(opportunities)
+      .where(eq(opportunities.id, app.opportunity_id))
+      .limit(1);
+    if (opp) opportunityTitle = opp.title;
+  }
+
+  const [{ rejection_reason }] = await db
+    .select({ rejection_reason: applications.rejection_reason })
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+
+  const { subject, html } = renderApplicantEmail(type, {
+    firstName: app.first_name,
+    opportunityTitle,
+    rejectionReason: rejection_reason,
+  });
+  await sendEmail(app.email, subject, html);
+  return { sent: true };
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: string }).code === "23505";
+}
+
+export type ScoreInput = { criterion_id: number; score: number; comment?: string };
+
+/**
+ * Upsert a reviewer's own criterion scores and return the weighted total. Each score is validated
+ * against its criterion's max_score. Weighted total = Σ(score/max * weight) / Σweight.
+ */
+export async function upsertScores(
+  applicationId: number,
+  reviewerUserId: number,
+  scores: ScoreInput[],
+) {
+  const [app] = await db
+    .select({ opportunity_id: applications.opportunity_id })
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  if (!app) throw new AppError("Application not found", 404);
+
+  const criteria = await db
+    .select()
+    .from(evaluation_criteria)
+    .where(eq(evaluation_criteria.opportunity_id, app.opportunity_id ?? -1));
+  const byId = new Map(criteria.map((c) => [c.id, c]));
+
+  for (const s of scores) {
+    const criterion = byId.get(s.criterion_id);
+    if (!criterion) throw new AppError(`Unknown criterion ${s.criterion_id}`, 400);
+    if (s.score < 0 || s.score > criterion.max_score) {
+      throw new AppError(
+        `Score for "${criterion.name}" must be between 0 and ${criterion.max_score}`,
+        422,
+      );
+    }
+  }
+
+  for (const s of scores) {
+    await db
+      .insert(application_scores)
+      .values({
+        application_id: applicationId,
+        criterion_id: s.criterion_id,
+        reviewer_user_id: reviewerUserId,
+        score: s.score,
+        comment: s.comment,
+      })
+      .onConflictDoUpdate({
+        target: [
+          application_scores.application_id,
+          application_scores.criterion_id,
+          application_scores.reviewer_user_id,
+        ],
+        set: { score: s.score, comment: s.comment, updated_at: new Date() },
+      });
+  }
+
+  return computeWeightedTotal(applicationId, reviewerUserId);
+}
+
+/** Weighted total for one reviewer over the opportunity's criteria. */
+export async function computeWeightedTotal(
+  applicationId: number,
+  reviewerUserId: number,
+): Promise<number> {
+  const [app] = await db
+    .select({ opportunity_id: applications.opportunity_id })
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  if (!app?.opportunity_id) return 0;
+
+  const criteria = await db
+    .select()
+    .from(evaluation_criteria)
+    .where(eq(evaluation_criteria.opportunity_id, app.opportunity_id));
+  const scores = await db
+    .select()
+    .from(application_scores)
+    .where(
+      and(
+        eq(application_scores.application_id, applicationId),
+        eq(application_scores.reviewer_user_id, reviewerUserId),
+      ),
+    );
+  const scoreByCriterion = new Map(scores.map((s) => [s.criterion_id, s.score]));
+
+  let weightedSum = 0;
+  let weightTotal = 0;
+  for (const c of criteria) {
+    const raw = scoreByCriterion.get(c.id);
+    if (raw == null) continue;
+    const weight = Number(c.weight);
+    weightedSum += (raw / c.max_score) * weight;
+    weightTotal += weight;
+  }
+  if (weightTotal === 0) return 0;
+  return Math.round((weightedSum / weightTotal) * 10000) / 10000;
+}
+
+// --- Queries (HR list/detail) ---
+
+/** Opportunities with a per-stage application count (one grouped query). */
+export async function listOpportunitiesWithStageCounts() {
+  const rows = await db
+    .select({
+      opportunity_id: opportunities.id,
+      title: opportunities.title,
+      status: opportunities.status,
+      stage: applications.pipeline_stage,
+      count: sql<number>`count(${applications.id})`,
+    })
+    .from(opportunities)
+    .leftJoin(applications, eq(applications.opportunity_id, opportunities.id))
+    .groupBy(
+      opportunities.id,
+      opportunities.title,
+      opportunities.status,
+      applications.pipeline_stage,
+    );
+
+  const byOpp = new Map<
+    number,
+    {
+      opportunity_id: number;
+      title: string;
+      status: string;
+      stages: Record<string, number>;
+      total: number;
+    }
+  >();
+  for (const r of rows) {
+    let entry = byOpp.get(r.opportunity_id);
+    if (!entry) {
+      entry = {
+        opportunity_id: r.opportunity_id,
+        title: r.title,
+        status: r.status,
+        stages: {},
+        total: 0,
+      };
+      byOpp.set(r.opportunity_id, entry);
+    }
+    if (r.stage) {
+      const n = Number(r.count);
+      entry.stages[r.stage] = n;
+      entry.total += n;
+    }
+  }
+  return [...byOpp.values()];
+}
+
+export type ApplicationListFilters = {
+  opportunity_id?: number;
+  stage?: string;
+  flagged?: boolean;
+  search?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export async function listApplications(filters: ApplicationListFilters) {
+  const page = Math.max(1, filters.page ?? 1);
+  const pageSize = Math.min(100, Math.max(1, filters.pageSize ?? 20));
+  const conds = [];
+  if (filters.opportunity_id) conds.push(eq(applications.opportunity_id, filters.opportunity_id));
+  if (filters.stage) conds.push(eq(applications.pipeline_stage, filters.stage));
+  if (filters.flagged !== undefined) conds.push(eq(applications.flagged, filters.flagged));
+  if (filters.search) {
+    const like = `%${filters.search}%`;
+    conds.push(
+      sql`(${applications.first_name} ILIKE ${like} OR ${applications.last_name} ILIKE ${like} OR ${applications.email} ILIKE ${like})`,
+    );
+  }
+  const where = conds.length ? and(...conds) : undefined;
+
+  const rows = await db
+    .select({
+      id: applications.id,
+      opportunity_id: applications.opportunity_id,
+      first_name: applications.first_name,
+      last_name: applications.last_name,
+      email: applications.email,
+      pipeline_stage: applications.pipeline_stage,
+      flagged: applications.flagged,
+      submission_date: applications.submission_date,
+    })
+    .from(applications)
+    .where(where)
+    .orderBy(sql`${applications.submission_date} desc`)
+    .limit(pageSize)
+    .offset((page - 1) * pageSize);
+
+  const [{ total }] = await db
+    .select({ total: sql<number>`count(*)` })
+    .from(applications)
+    .where(where);
+
+  return { data: rows, page, pageSize, total: Number(total) };
+}
+
+export async function getApplicationDetail(applicationId: number) {
+  const [app] = await db
+    .select()
+    .from(applications)
+    .where(eq(applications.id, applicationId))
+    .limit(1);
+  if (!app) throw new AppError("Application not found", 404);
+
+  const events = await db
+    .select()
+    .from(application_stage_events)
+    .where(eq(application_stage_events.application_id, applicationId))
+    .orderBy(application_stage_events.created_at);
+  const scores = await db
+    .select()
+    .from(application_scores)
+    .where(eq(application_scores.application_id, applicationId));
+  const emails = await db
+    .select()
+    .from(recruitment_emails)
+    .where(eq(recruitment_emails.application_id, applicationId));
+
+  return { application: app, stage_events: events, scores, emails };
+}
+
+// --- Screening rule CRUD ---
+
+export type ScreeningRuleInput = {
+  field_key: string;
+  operator: string;
+  value?: unknown;
+  action: string; // 'auto_reject' | 'flag'
+  email_template?: string | null;
+  rejection_reason?: string | null;
+  is_active?: boolean;
+};
+
+export async function listScreeningRules(opportunityId: number) {
+  return db
+    .select()
+    .from(screening_rules)
+    .where(eq(screening_rules.opportunity_id, opportunityId))
+    .orderBy(screening_rules.id);
+}
+
+export async function createScreeningRule(opportunityId: number, input: ScreeningRuleInput) {
+  const [row] = await db
+    .insert(screening_rules)
+    .values({
+      opportunity_id: opportunityId,
+      field_key: input.field_key,
+      operator: input.operator,
+      value: input.value ?? null,
+      action: input.action,
+      email_template: input.email_template ?? null,
+      rejection_reason: input.rejection_reason ?? null,
+      is_active: input.is_active ?? true,
+    })
+    .returning();
+  return row;
+}
+
+export async function updateScreeningRule(ruleId: number, input: Partial<ScreeningRuleInput>) {
+  const patch: Record<string, unknown> = { updated_at: new Date() };
+  for (const k of [
+    "field_key",
+    "operator",
+    "value",
+    "action",
+    "email_template",
+    "rejection_reason",
+    "is_active",
+  ] as const) {
+    if (input[k] !== undefined) patch[k] = input[k];
+  }
+  const [row] = await db
+    .update(screening_rules)
+    .set(patch)
+    .where(eq(screening_rules.id, ruleId))
+    .returning();
+  if (!row) throw new AppError("Screening rule not found", 404);
+  return row;
+}
+
+export async function deleteScreeningRule(ruleId: number) {
+  const [rule] = await db
+    .select()
+    .from(screening_rules)
+    .where(eq(screening_rules.id, ruleId))
+    .limit(1);
+  if (!rule) throw new AppError("Screening rule not found", 404);
+  if (rule.hit_count > 0) {
+    await db
+      .update(screening_rules)
+      .set({ is_active: false, updated_at: new Date() })
+      .where(eq(screening_rules.id, ruleId));
+    return { deleted: false, deactivated: true };
+  }
+  await db.delete(screening_rules).where(eq(screening_rules.id, ruleId));
+  return { deleted: true, deactivated: false };
+}
+
+// --- Evaluation criteria CRUD ---
+
+export type CriterionInput = {
+  name: string;
+  weight?: string | number;
+  max_score?: number;
+  sort_order?: number;
+};
+
+export async function listCriteria(opportunityId: number) {
+  return db
+    .select()
+    .from(evaluation_criteria)
+    .where(eq(evaluation_criteria.opportunity_id, opportunityId))
+    .orderBy(evaluation_criteria.sort_order, evaluation_criteria.id);
+}
+
+export async function createCriterion(opportunityId: number, input: CriterionInput) {
+  const [row] = await db
+    .insert(evaluation_criteria)
+    .values({
+      opportunity_id: opportunityId,
+      name: input.name,
+      weight: input.weight != null ? String(input.weight) : undefined,
+      max_score: input.max_score,
+      sort_order: input.sort_order,
+    })
+    .returning();
+  return row;
+}
+
+export async function updateCriterion(criterionId: number, input: Partial<CriterionInput>) {
+  const patch: Record<string, unknown> = { updated_at: new Date() };
+  if (input.name !== undefined) patch.name = input.name;
+  if (input.weight !== undefined) patch.weight = String(input.weight);
+  if (input.max_score !== undefined) patch.max_score = input.max_score;
+  if (input.sort_order !== undefined) patch.sort_order = input.sort_order;
+  const [row] = await db
+    .update(evaluation_criteria)
+    .set(patch)
+    .where(eq(evaluation_criteria.id, criterionId))
+    .returning();
+  if (!row) throw new AppError("Criterion not found", 404);
+  return row;
+}
+
+/** Delete a criterion — blocked while any scores reference it (spec §4). */
+export async function deleteCriterion(criterionId: number) {
+  const [scored] = await db
+    .select({ id: application_scores.id })
+    .from(application_scores)
+    .where(eq(application_scores.criterion_id, criterionId))
+    .limit(1);
+  if (scored) throw new AppError("Cannot delete a criterion that already has scores", 409);
+  await db.delete(evaluation_criteria).where(eq(evaluation_criteria.id, criterionId));
+  return { deleted: true };
+}

--- a/backend/src/validations/recruitment-pipeline.ts
+++ b/backend/src/validations/recruitment-pipeline.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { RULE_OPERATORS } from "../types/recruitment";
+import { PIPELINE_STAGES } from "../db/schema/recruitment/pipeline";
+
+const idParam = z
+  .string()
+  .refine((v) => !Number.isNaN(parseInt(v)), { message: "ID must be a number" })
+  .transform((v) => parseInt(v));
+
+const operatorEnum = z.enum(RULE_OPERATORS as unknown as [string, ...string[]]);
+const stageEnum = z.enum(PIPELINE_STAGES as unknown as [string, ...string[]]);
+
+export const idParamSchema = z.object({ params: z.object({ id: idParam }) });
+
+export const transitionSchema = z.object({
+  params: z.object({ id: idParam }),
+  body: z.object({
+    to_stage: stageEnum,
+    note: z.string().optional(),
+    send_email: z.boolean().optional(),
+  }),
+});
+
+export const createScreeningRuleSchema = z.object({
+  params: z.object({ id: idParam }),
+  body: z.object({
+    field_key: z.string().min(1),
+    operator: operatorEnum,
+    value: z.unknown().optional(),
+    action: z.enum(["auto_reject", "flag"]),
+    email_template: z.string().nullable().optional(),
+    rejection_reason: z.string().nullable().optional(),
+    is_active: z.boolean().optional(),
+  }),
+});
+
+export const patchScreeningRuleSchema = z.object({
+  params: z.object({ id: idParam, ruleId: idParam }),
+  body: z.object({
+    field_key: z.string().min(1).optional(),
+    operator: operatorEnum.optional(),
+    value: z.unknown().optional(),
+    action: z.enum(["auto_reject", "flag"]).optional(),
+    email_template: z.string().nullable().optional(),
+    rejection_reason: z.string().nullable().optional(),
+    is_active: z.boolean().optional(),
+  }),
+});
+
+export const screeningRuleIdSchema = z.object({
+  params: z.object({ id: idParam, ruleId: idParam }),
+});
+
+export const createCriterionSchema = z.object({
+  params: z.object({ id: idParam }),
+  body: z.object({
+    name: z.string().min(1),
+    weight: z.union([z.number(), z.string()]).optional(),
+    max_score: z.number().int().positive().optional(),
+    sort_order: z.number().int().optional(),
+  }),
+});
+
+export const patchCriterionSchema = z.object({
+  params: z.object({ id: idParam, criterionId: idParam }),
+  body: z.object({
+    name: z.string().min(1).optional(),
+    weight: z.union([z.number(), z.string()]).optional(),
+    max_score: z.number().int().positive().optional(),
+    sort_order: z.number().int().optional(),
+  }),
+});
+
+export const criterionIdSchema = z.object({
+  params: z.object({ id: idParam, criterionId: idParam }),
+});
+
+export const putScoresSchema = z.object({
+  params: z.object({ id: idParam }),
+  body: z.object({
+    scores: z.array(
+      z.object({
+        criterion_id: z.number().int(),
+        score: z.number().int(),
+        comment: z.string().optional(),
+      }),
+    ),
+  }),
+});

--- a/backend/tests/factories/index.ts
+++ b/backend/tests/factories/index.ts
@@ -11,6 +11,9 @@ import {
   opportunities,
   opportunity_forms,
   eligibility_rules,
+  applications,
+  screening_rules,
+  evaluation_criteria,
 } from "../../src/db/schema";
 import { eq } from "drizzle-orm";
 import * as authService from "../../src/services/auth.service";
@@ -183,6 +186,92 @@ export async function makeRule(opts: {
       is_active: opts.is_active ?? true,
       sort_order: opts.sort_order ?? 0,
       hit_count: opts.hit_count ?? 0,
+    })
+    .returning();
+  return row;
+}
+
+/** Insert an application row (REC-02 pipeline tests). Fills every NOT NULL column. */
+export async function makeApplication(opts: {
+  opportunityId?: number | null;
+  pipeline_stage?: string;
+  userId?: number | null;
+  overrides?: Record<string, unknown>;
+}) {
+  const [row] = await db
+    .insert(applications)
+    .values({
+      opportunity_id: opts.opportunityId ?? null,
+      first_name: "Jane",
+      last_name: "Doe",
+      email: `applicant_${uniq()}@test.local`,
+      phone: "+250700000000",
+      national_id: `ID${uniq()}`,
+      city: "Kigali",
+      country: "Rwanda",
+      education_level: "bachelors_degree",
+      field_of_study: "Computer Science",
+      career_experience: "3 years",
+      cv_url: "https://files.example.com/cv.pdf",
+      motivation: "Motivated.",
+      five_year_vision: "Vision.",
+      desired_impact: "Impact.",
+      community_role: "Mentor.",
+      national_strategy: "Aligned.",
+      how_ganzafrica_can_help: "Growth.",
+      contribution_to_ganzafrica: "Skills.",
+      data_processing_consent: true,
+      pipeline_stage: opts.pipeline_stage ?? "submitted",
+      user_id: opts.userId ?? null,
+      ...(opts.overrides ?? {}),
+    } as any)
+    .returning();
+  return row;
+}
+
+export async function makeScreeningRule(opts: {
+  opportunityId: number;
+  field_key: string;
+  operator: string;
+  value?: unknown;
+  action: "auto_reject" | "flag";
+  email_template?: string | null;
+  rejection_reason?: string | null;
+  is_active?: boolean;
+  hit_count?: number;
+}) {
+  const [row] = await db
+    .insert(screening_rules)
+    .values({
+      opportunity_id: opts.opportunityId,
+      field_key: opts.field_key,
+      operator: opts.operator,
+      value: (opts.value ?? null) as any,
+      action: opts.action,
+      email_template: opts.email_template ?? null,
+      rejection_reason: opts.rejection_reason ?? null,
+      is_active: opts.is_active ?? true,
+      hit_count: opts.hit_count ?? 0,
+    })
+    .returning();
+  return row;
+}
+
+export async function makeCriterion(opts: {
+  opportunityId: number;
+  name?: string;
+  weight?: string | number;
+  max_score?: number;
+  sort_order?: number;
+}) {
+  const [row] = await db
+    .insert(evaluation_criteria)
+    .values({
+      opportunity_id: opts.opportunityId,
+      name: opts.name ?? `Criterion ${uniq()}`,
+      weight: opts.weight != null ? String(opts.weight) : "1",
+      max_score: opts.max_score ?? 5,
+      sort_order: opts.sort_order ?? 0,
     })
     .returning();
   return row;

--- a/backend/tests/integration/recruitment-forms-service.test.ts
+++ b/backend/tests/integration/recruitment-forms-service.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resetDb } from "../setup";
+import { makeUser, makeOpportunity, makeRule } from "../factories";
+import * as forms from "../../src/services/recruitment/forms.service";
+import type { FormDefinition } from "../../src/types/recruitment";
+
+const emptyDef: FormDefinition = { standard: [], custom: [] };
+
+describe("REC-01 forms.service edge paths", () => {
+  let userId: number;
+  let oppId: number;
+
+  beforeEach(async () => {
+    await resetDb();
+    userId = (await makeUser({ role: "hr" })).id;
+    oppId = (await makeOpportunity({ createdBy: userId })).id;
+  });
+
+  it("saveDraft creates then overwrites the same draft (no new version)", async () => {
+    const first = await forms.saveDraft(oppId, emptyDef, userId);
+    const second = await forms.saveDraft(
+      oppId,
+      {
+        standard: [],
+        custom: [{ key: "x", label: "X", type: "text", required: false, order: 1, section: "S" }],
+      },
+      userId,
+    );
+    expect(second.id).toBe(first.id); // overwrote, not appended
+    expect(second.version).toBe(first.version);
+  });
+
+  it("publishDraft with no draft throws 400", async () => {
+    await expect(forms.publishDraft(oppId)).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("updateRule patches provided fields and 404s on unknown id", async () => {
+    const rule = await makeRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "gt",
+      value: 30,
+    });
+    const updated = await forms.updateRule(rule.id, {
+      operator: "gte",
+      value: 25,
+      is_active: false,
+      reject_message: "Updated",
+    });
+    expect(updated.operator).toBe("gte");
+    expect(updated.is_active).toBe(false);
+    expect(updated.reject_message).toBe("Updated");
+
+    await expect(forms.updateRule(999999, { operator: "lt" })).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("getActiveRules returns only active rules in sort order", async () => {
+    await makeRule({
+      opportunityId: oppId,
+      field_key: "a",
+      operator: "eq",
+      value: "1",
+      is_active: true,
+      sort_order: 2,
+    });
+    await makeRule({
+      opportunityId: oppId,
+      field_key: "b",
+      operator: "eq",
+      value: "2",
+      is_active: true,
+      sort_order: 1,
+    });
+    await makeRule({
+      opportunityId: oppId,
+      field_key: "c",
+      operator: "eq",
+      value: "3",
+      is_active: false,
+    });
+    const active = await forms.getActiveRules(oppId);
+    expect(active.map((r) => r.field_key)).toEqual(["b", "a"]);
+  });
+
+  it("deleteOrDeactivateRule deactivates a hit rule and 404s on unknown", async () => {
+    const hit = await makeRule({
+      opportunityId: oppId,
+      field_key: "a",
+      operator: "eq",
+      value: "1",
+      hit_count: 5,
+    });
+    const res = await forms.deleteOrDeactivateRule(hit.id);
+    expect(res).toMatchObject({ deleted: false, deactivated: true });
+    await expect(forms.deleteOrDeactivateRule(999999)).rejects.toMatchObject({ statusCode: 404 });
+  });
+});

--- a/backend/tests/integration/recruitment-pipeline-crud.test.ts
+++ b/backend/tests/integration/recruitment-pipeline-crud.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "../../src/db/client";
+import { screening_rules, evaluation_criteria } from "../../src/db/schema";
+import { eq } from "drizzle-orm";
+import { resetDb } from "../setup";
+import {
+  makeUser,
+  makeOpportunity,
+  makeApplication,
+  makeScreeningRule,
+  makeCriterion,
+} from "../factories";
+
+const sendEmailMock = vi.fn(async () => ({ id: "mock" }));
+vi.mock("../../src/services/email.service", () => ({
+  sendEmail: (...a: unknown[]) => sendEmailMock(...a),
+}));
+
+import * as pipeline from "../../src/services/recruitment/pipeline.service";
+import {
+  renderApplicantEmail,
+  type ApplicantEmailType,
+} from "../../src/services/recruitment/email-templates";
+
+describe("REC-02 email templates", () => {
+  const types: ApplicantEmailType[] = [
+    "received",
+    "rejected",
+    "shortlisted",
+    "interview",
+    "offer",
+    "hired",
+  ];
+  for (const t of types) {
+    it(`renders the ${t} template with subject + html`, () => {
+      const { subject, html } = renderApplicantEmail(t, {
+        firstName: "Ada",
+        opportunityTitle: "Fellowship",
+        rejectionReason: t === "rejected" ? "Not a match this round." : null,
+      });
+      expect(subject).toContain("Fellowship");
+      expect(html).toContain("Ada");
+      expect(html).toContain("GanzAfrica");
+    });
+  }
+
+  it("rejected template falls back to default copy when no reason is given", () => {
+    const { html } = renderApplicantEmail("rejected", {
+      firstName: "Ada",
+      opportunityTitle: "Fellowship",
+      rejectionReason: "   ",
+    });
+    expect(html).toContain("won't be moving forward");
+  });
+});
+
+describe("REC-02 pipeline queries + CRUD", () => {
+  let hrId: number;
+  let oppId: number;
+
+  beforeEach(async () => {
+    await resetDb();
+    sendEmailMock.mockClear();
+    hrId = (await makeUser({ role: "hr" })).id;
+    oppId = (await makeOpportunity({ createdBy: hrId })).id;
+  });
+
+  it("listOpportunitiesWithStageCounts groups by stage", async () => {
+    await makeApplication({ opportunityId: oppId, pipeline_stage: "submitted" });
+    await makeApplication({ opportunityId: oppId, pipeline_stage: "submitted" });
+    await makeApplication({ opportunityId: oppId, pipeline_stage: "screening" });
+
+    const result = await pipeline.listOpportunitiesWithStageCounts();
+    const opp = result.find((o) => o.opportunity_id === oppId)!;
+    expect(opp.total).toBe(3);
+    expect(opp.stages.submitted).toBe(2);
+    expect(opp.stages.screening).toBe(1);
+  });
+
+  it("listApplications filters by stage, flagged, and search + paginates", async () => {
+    await makeApplication({
+      opportunityId: oppId,
+      overrides: { first_name: "Zara", flagged: true },
+    });
+    await makeApplication({ opportunityId: oppId, pipeline_stage: "screening" });
+
+    const byStage = await pipeline.listApplications({ opportunity_id: oppId, stage: "screening" });
+    expect(byStage.total).toBe(1);
+
+    const flagged = await pipeline.listApplications({ opportunity_id: oppId, flagged: true });
+    expect(flagged.total).toBe(1);
+
+    const search = await pipeline.listApplications({ opportunity_id: oppId, search: "Zara" });
+    expect(search.total).toBe(1);
+
+    const paged = await pipeline.listApplications({ opportunity_id: oppId, page: 1 });
+    expect(paged.page).toBe(1);
+  });
+
+  it("getApplicationDetail returns events, scores, emails", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId });
+    await pipeline.transition(appRow.id, "screening", hrId, { note: "n" });
+    const detail = await pipeline.getApplicationDetail(appRow.id);
+    expect(detail.application.id).toBe(appRow.id);
+    expect(detail.stage_events.length).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(detail.scores)).toBe(true);
+    expect(Array.isArray(detail.emails)).toBe(true);
+  });
+
+  it("getApplicationDetail throws 404 for a missing application", async () => {
+    await expect(pipeline.getApplicationDetail(999999)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("screening rule CRUD: create, update, delete (and deactivate-when-hit)", async () => {
+    const created = await pipeline.createScreeningRule(oppId, {
+      field_key: "age",
+      operator: "gt",
+      value: 40,
+      action: "flag",
+    });
+    expect(created.action).toBe("flag");
+
+    const listed = await pipeline.listScreeningRules(oppId);
+    expect(listed).toHaveLength(1);
+
+    const updated = await pipeline.updateScreeningRule(created.id, {
+      action: "auto_reject",
+      is_active: false,
+    });
+    expect(updated.action).toBe("auto_reject");
+    expect(updated.is_active).toBe(false);
+
+    const del = await pipeline.deleteScreeningRule(created.id);
+    expect(del).toMatchObject({ deleted: true, deactivated: false });
+
+    const hitRule = await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "gt",
+      value: 40,
+      action: "flag",
+      hit_count: 2,
+    });
+    const del2 = await pipeline.deleteScreeningRule(hitRule.id);
+    expect(del2).toMatchObject({ deleted: false, deactivated: true });
+    const [row] = await db.select().from(screening_rules).where(eq(screening_rules.id, hitRule.id));
+    expect(row.is_active).toBe(false);
+  });
+
+  it("updateScreeningRule throws 404 for unknown id", async () => {
+    await expect(pipeline.updateScreeningRule(999999, { action: "flag" })).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("criteria CRUD: create, update, list, delete; block delete when scored", async () => {
+    const c = await pipeline.createCriterion(oppId, {
+      name: "Motivation",
+      weight: 2,
+      max_score: 5,
+    });
+    expect(c.name).toBe("Motivation");
+
+    const updated = await pipeline.updateCriterion(c.id, {
+      name: "Drive",
+      weight: 3,
+      max_score: 10,
+      sort_order: 2,
+    });
+    expect(updated.name).toBe("Drive");
+    expect(Number(updated.weight)).toBe(3);
+
+    const listed = await pipeline.listCriteria(oppId);
+    expect(listed).toHaveLength(1);
+
+    // Score it, then deletion must be blocked (409).
+    const appRow = await makeApplication({ opportunityId: oppId });
+    await pipeline.upsertScores(appRow.id, hrId, [{ criterion_id: c.id, score: 3 }]);
+    await expect(pipeline.deleteCriterion(c.id)).rejects.toMatchObject({ statusCode: 409 });
+
+    // An unscored criterion deletes cleanly.
+    const c2 = await makeCriterion({ opportunityId: oppId });
+    const del = await pipeline.deleteCriterion(c2.id);
+    expect(del).toMatchObject({ deleted: true });
+    const remaining = await db
+      .select()
+      .from(evaluation_criteria)
+      .where(eq(evaluation_criteria.id, c2.id));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("updateCriterion throws 404 for unknown id", async () => {
+    await expect(pipeline.updateCriterion(999999, { name: "x" })).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("transition to unknown stage throws 400; unknown application throws 404", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId });
+    await expect(pipeline.transition(appRow.id, "nonsense", hrId)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+    await expect(pipeline.transition(999999, "screening", hrId)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("sendApplicantEmail no-ops for a missing application after reserving the row", async () => {
+    // reserve then delete would be contrived; instead assert a fresh type sends once
+    const appRow = await makeApplication({ opportunityId: oppId });
+    const r = await pipeline.sendApplicantEmail(appRow.id, "shortlisted");
+    expect(r.sent).toBe(true);
+  });
+
+  it("optimistic concurrency: a stale transition (already moved) throws 409-shaped error", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId });
+    await pipeline.transition(appRow.id, "screening", hrId); // now in screening
+    // Try to move as if still submitted → the WHERE stage guard won't match the fresh read path.
+    await expect(pipeline.transition(appRow.id, "screening", hrId)).rejects.toMatchObject({
+      name: "IllegalTransitionError",
+    });
+  });
+
+  it("computeWeightedTotal returns 0 with no criteria and no opportunity", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId });
+    expect(await pipeline.computeWeightedTotal(appRow.id, hrId)).toBe(0); // no criteria
+    const orphan = await makeApplication({ opportunityId: null });
+    expect(await pipeline.computeWeightedTotal(orphan.id, hrId)).toBe(0); // no opportunity
+  });
+
+  it("listApplications with no filters returns everything", async () => {
+    await makeApplication({ opportunityId: oppId });
+    await makeApplication({ opportunityId: oppId });
+    const all = await pipeline.listApplications({});
+    expect(all.total).toBeGreaterThanOrEqual(2);
+  });
+
+  it("flag rule without a rejection_reason uses a default note", async () => {
+    const appRow = await makeApplication({
+      opportunityId: oppId,
+      overrides: { country_of_residence: "Rwanda" },
+    });
+    await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "country_of_residence",
+      operator: "eq",
+      value: "Rwanda",
+      action: "flag",
+    });
+    await pipeline.runScreening(appRow.id);
+    const detail = await pipeline.getApplicationDetail(appRow.id);
+    expect(detail.application.flagged).toBe(true);
+    expect(detail.application.flag_note).toContain("Flagged by rule");
+  });
+
+  it("runScreening no-ops for an application already past submitted", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId, pipeline_stage: "screening" });
+    await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "gt",
+      value: 0,
+      action: "auto_reject",
+    });
+    await pipeline.runScreening(appRow.id);
+    const detail = await pipeline.getApplicationDetail(appRow.id);
+    expect(detail.application.pipeline_stage).toBe("screening"); // untouched
+  });
+
+  it("runScreening no-ops for an application with no opportunity", async () => {
+    const orphan = await makeApplication({ opportunityId: null });
+    await expect(pipeline.runScreening(orphan.id)).resolves.toBeUndefined();
+  });
+
+  it("upsertScores rejects an unknown criterion (400)", async () => {
+    const appRow = await makeApplication({ opportunityId: oppId });
+    await expect(
+      pipeline.upsertScores(appRow.id, hrId, [{ criterion_id: 999999, score: 1 }]),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("upsertScores 404s for an unknown application", async () => {
+    await expect(pipeline.upsertScores(999999, hrId, [])).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("deleteScreeningRule 404s for an unknown id", async () => {
+    await expect(pipeline.deleteScreeningRule(999999)).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it("createScreeningRule and createCriterion apply defaults (no value / no weight)", async () => {
+    const rule = await pipeline.createScreeningRule(oppId, {
+      field_key: "has_work_permit",
+      operator: "is_false",
+      action: "flag",
+    });
+    expect(rule.value).toBeNull();
+
+    const criterion = await pipeline.createCriterion(oppId, { name: "Fit" });
+    expect(Number(criterion.weight)).toBe(1); // default
+    expect(criterion.max_score).toBe(5); // default
+  });
+});

--- a/backend/tests/integration/recruitment-pipeline.test.ts
+++ b/backend/tests/integration/recruitment-pipeline.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { db } from "../../src/db/client";
+import {
+  applications,
+  application_stage_events,
+  recruitment_emails,
+  screening_rules,
+} from "../../src/db/schema";
+import { eq } from "drizzle-orm";
+import { resetDb } from "../setup";
+import { makeUser, makeOpportunity, makeApplication, makeScreeningRule } from "../factories";
+
+// Count Resend sends without hitting the network.
+const sendEmailMock = vi.fn(async () => ({ id: "mock" }));
+vi.mock("../../src/services/email.service", () => ({
+  sendEmail: (...args: unknown[]) => sendEmailMock(...args),
+}));
+
+import * as pipeline from "../../src/services/recruitment/pipeline.service";
+
+describe("REC-02 pipeline service", () => {
+  let hrId: number;
+  let oppId: number;
+
+  beforeEach(async () => {
+    await resetDb();
+    sendEmailMock.mockClear();
+    hrId = (await makeUser({ role: "hr" })).id;
+    oppId = (await makeOpportunity({ createdBy: hrId })).id;
+  });
+
+  // §6.1 transition matrix (integration side — legal move + audit trail)
+  it("transition moves the stage and writes a stage event", async () => {
+    const app = await makeApplication({ opportunityId: oppId });
+    await pipeline.transition(app.id, "screening", hrId, { note: "start review" });
+
+    const [row] = await db.select().from(applications).where(eq(applications.id, app.id));
+    expect(row.pipeline_stage).toBe("screening");
+    expect(row.status).toBe("under_review"); // legacy sync
+
+    const events = await db
+      .select()
+      .from(application_stage_events)
+      .where(eq(application_stage_events.application_id, app.id));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      from_stage: "submitted",
+      to_stage: "screening",
+      actor_user_id: hrId,
+    });
+  });
+
+  it("illegal transition throws with the allowed set (→ 409 in controller)", async () => {
+    const app = await makeApplication({ opportunityId: oppId });
+    await expect(pipeline.transition(app.id, "hired", hrId)).rejects.toMatchObject({
+      name: "IllegalTransitionError",
+      allowed: ["screening", "rejected", "withdrawn"],
+    });
+  });
+
+  // §6.2 email is post-commit / non-blocking — a mail failure never rolls back the move
+  it("stage still moves when the applicant email fails", async () => {
+    sendEmailMock.mockRejectedValueOnce(new Error("resend down"));
+    const app = await makeApplication({ opportunityId: oppId, pipeline_stage: "screening" });
+    await pipeline.transition(app.id, "shortlisted", hrId, { sendEmailToApplicant: true });
+
+    const [row] = await db.select().from(applications).where(eq(applications.id, app.id));
+    expect(row.pipeline_stage).toBe("shortlisted"); // moved despite email failure
+  });
+
+  // §6.3 auto_reject screening → rejected, actor NULL, reason set, one rejected email
+  it("auto_reject screening rejects with actor NULL, reason, and one email", async () => {
+    const app = await makeApplication({
+      opportunityId: oppId,
+      overrides: { date_of_birth: "1980-01-01" },
+    });
+    await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "gt",
+      value: 30,
+      action: "auto_reject",
+      email_template: "rejected",
+      rejection_reason: "Outside the age range for this role.",
+    });
+
+    await pipeline.runScreening(app.id);
+
+    const [row] = await db.select().from(applications).where(eq(applications.id, app.id));
+    expect(row.pipeline_stage).toBe("rejected");
+    expect(row.rejection_reason).toBe("Outside the age range for this role.");
+
+    const events = await db
+      .select()
+      .from(application_stage_events)
+      .where(eq(application_stage_events.application_id, app.id));
+    expect(events[0].actor_user_id).toBeNull(); // automation
+
+    const emails = await db
+      .select()
+      .from(recruitment_emails)
+      .where(eq(recruitment_emails.application_id, app.id));
+    expect(emails.filter((e) => e.email_type === "rejected")).toHaveLength(1);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("flag screening flags without an email", async () => {
+    const app = await makeApplication({
+      opportunityId: oppId,
+      overrides: { country_of_residence: "Rwanda" },
+    });
+    await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "country_of_residence",
+      operator: "eq",
+      value: "Rwanda",
+      action: "flag",
+      rejection_reason: "Manual review: local applicant.",
+    });
+
+    await pipeline.runScreening(app.id);
+
+    const [row] = await db.select().from(applications).where(eq(applications.id, app.id));
+    expect(row.flagged).toBe(true);
+    expect(row.flag_note).toContain("Manual review");
+    expect(row.pipeline_stage).toBe("submitted"); // not rejected
+    expect(sendEmailMock).not.toHaveBeenCalled();
+  });
+
+  // §6.4 screening error injection never breaks anything
+  it("a garbage-operator rule is skipped; application stays submitted", async () => {
+    const app = await makeApplication({ opportunityId: oppId });
+    await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "explode",
+      value: 1,
+      action: "auto_reject",
+    });
+
+    await expect(pipeline.runScreening(app.id)).resolves.toBeUndefined();
+    const [row] = await db.select().from(applications).where(eq(applications.id, app.id));
+    expect(row.pipeline_stage).toBe("submitted");
+  });
+
+  // §6.5 email idempotency: two sends → one row, one Resend call
+  it("applicant email is sent once per (application, type)", async () => {
+    const app = await makeApplication({ opportunityId: oppId });
+    const first = await pipeline.sendApplicantEmail(app.id, "received");
+    const second = await pipeline.sendApplicantEmail(app.id, "received");
+
+    expect(first.sent).toBe(true);
+    expect(second.sent).toBe(false);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+
+    const rows = await db
+      .select()
+      .from(recruitment_emails)
+      .where(eq(recruitment_emails.application_id, app.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("records a hit on each matched screening rule", async () => {
+    const app = await makeApplication({
+      opportunityId: oppId,
+      overrides: { date_of_birth: "1980-01-01" },
+    });
+    const rule = await makeScreeningRule({
+      opportunityId: oppId,
+      field_key: "age",
+      operator: "gt",
+      value: 30,
+      action: "flag",
+    });
+    await pipeline.runScreening(app.id);
+    const [row] = await db.select().from(screening_rules).where(eq(screening_rules.id, rule.id));
+    expect(row.hit_count).toBe(1);
+  });
+});

--- a/backend/tests/integration/recruitment-scores-perms.test.ts
+++ b/backend/tests/integration/recruitment-scores-perms.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import supertest from "supertest";
+import app from "../../src/app";
+import { db } from "../../src/db/client";
+import { application_scores } from "../../src/db/schema";
+import { eq, and } from "drizzle-orm";
+import { resetDb } from "../setup";
+import { loginAs } from "../helpers/auth";
+import { grant } from "../helpers/rbac";
+import { clearPermissionCache } from "../../src/middlewares";
+import { makeUser, makeOpportunity, makeApplication, makeCriterion } from "../factories";
+
+vi.mock("../../src/services/email.service", () => ({
+  sendEmail: vi.fn(async () => ({ id: "x" })),
+}));
+
+import * as pipeline from "../../src/services/recruitment/pipeline.service";
+
+describe("REC-02 weighted scoring", () => {
+  let hrId: number;
+  let oppId: number;
+  let appId: number;
+
+  beforeEach(async () => {
+    await resetDb();
+    clearPermissionCache();
+    hrId = (await makeUser({ role: "hr" })).id;
+    oppId = (await makeOpportunity({ createdBy: hrId })).id;
+    appId = (await makeApplication({ opportunityId: oppId })).id;
+  });
+
+  // §6.6 weighted math with weights 2/1/1
+  it("computes the weighted total (weights 2/1/1)", async () => {
+    const c1 = await makeCriterion({ opportunityId: oppId, weight: 2, max_score: 5 });
+    const c2 = await makeCriterion({ opportunityId: oppId, weight: 1, max_score: 5 });
+    const c3 = await makeCriterion({ opportunityId: oppId, weight: 1, max_score: 5 });
+
+    const total = await pipeline.upsertScores(appId, hrId, [
+      { criterion_id: c1.id, score: 5 }, // 1.0 * 2
+      { criterion_id: c2.id, score: 0 }, // 0.0 * 1
+      { criterion_id: c3.id, score: 5 }, // 1.0 * 1
+    ]);
+    // (2 + 0 + 1) / 4 = 0.75
+    expect(total).toBeCloseTo(0.75, 4);
+  });
+
+  it("upsert overwrites the reviewer's own score, not others'", async () => {
+    const other = await makeUser({ role: "hr" });
+    const c1 = await makeCriterion({ opportunityId: oppId, weight: 1, max_score: 5 });
+
+    await pipeline.upsertScores(appId, other.id, [{ criterion_id: c1.id, score: 2 }]);
+    await pipeline.upsertScores(appId, hrId, [{ criterion_id: c1.id, score: 4 }]);
+    await pipeline.upsertScores(appId, hrId, [{ criterion_id: c1.id, score: 5 }]); // overwrite own
+
+    const rows = await db
+      .select()
+      .from(application_scores)
+      .where(eq(application_scores.application_id, appId));
+    expect(rows).toHaveLength(2); // one per reviewer
+    const mine = rows.find((r) => r.reviewer_user_id === hrId);
+    const theirs = rows.find((r) => r.reviewer_user_id === other.id);
+    expect(mine!.score).toBe(5);
+    expect(theirs!.score).toBe(2); // untouched
+  });
+
+  it("score above max_score is rejected (422)", async () => {
+    const c1 = await makeCriterion({ opportunityId: oppId, max_score: 5 });
+    await expect(
+      pipeline.upsertScores(appId, hrId, [{ criterion_id: c1.id, score: 9 }]),
+    ).rejects.toMatchObject({
+      statusCode: 422,
+    });
+  });
+});
+
+describe("REC-02 permissions", () => {
+  let hrId: number;
+  let oppId: number;
+  let appId: number;
+
+  beforeEach(async () => {
+    await resetDb();
+    clearPermissionCache();
+    hrId = (await makeUser({ role: "hr" })).id;
+    oppId = (await makeOpportunity({ createdBy: hrId })).id;
+    appId = (await makeApplication({ opportunityId: oppId })).id;
+  });
+
+  it("staff → 403 on the applications list", async () => {
+    const { agent } = await loginAs("staff");
+    const res = await agent.get("/api/hr/recruitment/applications");
+    expect(res.status).toBe(403);
+  });
+
+  it("director reads lists but is 403 on transition", async () => {
+    await grant("director", "recruitment", "read");
+    const { agent } = await loginAs("director");
+
+    const list = await agent.get("/api/hr/recruitment/applications");
+    expect(list.status).toBe(200);
+
+    const move = await agent
+      .post(`/api/hr/recruitment/applications/${appId}/transition`)
+      .send({ to_stage: "screening" });
+    expect(move.status).toBe(403);
+  });
+
+  it("hr with recruitment:manage can transition", async () => {
+    await grant("hr", "recruitment", "manage");
+    const { agent } = await loginAs("hr");
+    const res = await agent
+      .post(`/api/hr/recruitment/applications/${appId}/transition`)
+      .send({ to_stage: "screening" });
+    expect(res.status).toBe(200);
+    expect(res.body.application.pipeline_stage).toBe("screening");
+  });
+
+  it("illegal transition via API → 409 with allowed set", async () => {
+    await grant("hr", "recruitment", "manage");
+    const { agent } = await loginAs("hr");
+    const res = await agent
+      .post(`/api/hr/recruitment/applications/${appId}/transition`)
+      .send({ to_stage: "hired" });
+    expect(res.status).toBe(409);
+    expect(res.body.allowed).toEqual(["screening", "rejected", "withdrawn"]);
+  });
+});

--- a/backend/tests/unit/eligibility-evaluate.test.ts
+++ b/backend/tests/unit/eligibility-evaluate.test.ts
@@ -172,6 +172,36 @@ describe("evaluate — operator table", () => {
     expect(evaluate([r], { x: "anything" }).eligible).toBe(true);
   });
 
+  it("covers non-matching and non-coercible branches", () => {
+    // neq that does NOT reject (values equal)
+    expect(
+      evaluate([rule({ field_key: "d", operator: "neq", value: "x" })], { d: "x" }).eligible,
+    ).toBe(true);
+    // numeric comparison where the operand can't be coerced → no reject
+    expect(
+      evaluate([rule({ field_key: "n", operator: "gt", value: "abc" })], { n: 5 }).eligible,
+    ).toBe(true);
+    // gte/lte non-matching
+    expect(
+      evaluate([rule({ field_key: "n", operator: "gte", value: 10 })], { n: 5 }).eligible,
+    ).toBe(true);
+    expect(evaluate([rule({ field_key: "n", operator: "lte", value: 3 })], { n: 5 }).eligible).toBe(
+      true,
+    );
+    // contains against a non-string, non-array value → no reject
+    expect(
+      evaluate([rule({ field_key: "k", operator: "contains", value: "z" })], { k: 42 }).eligible,
+    ).toBe(true);
+    // in / not_in with a non-array operand → no reject / reject-guard
+    expect(
+      evaluate([rule({ field_key: "k", operator: "in", value: "notarray" })], { k: "a" }).eligible,
+    ).toBe(true);
+    expect(
+      evaluate([rule({ field_key: "k", operator: "not_in", value: "notarray" })], { k: "a" })
+        .eligible,
+    ).toBe(true);
+  });
+
   it("multiple failing rules accumulate", () => {
     const r1 = rule({ field_key: "age", operator: "gt", value: 30, reject_message: "Too old" });
     const r2 = rule({

--- a/backend/tests/unit/pipeline-matrix.test.ts
+++ b/backend/tests/unit/pipeline-matrix.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALLOWED_TRANSITIONS,
+  LEGACY_STATUS_MAP,
+  isValidStage,
+} from "../../src/services/recruitment/pipeline.service";
+import { PIPELINE_STAGES } from "../../src/db/schema/recruitment/pipeline";
+
+describe("pipeline transition matrix", () => {
+  const legal: [string, string][] = [
+    ["submitted", "screening"],
+    ["submitted", "rejected"],
+    ["submitted", "withdrawn"],
+    ["screening", "shortlisted"],
+    ["shortlisted", "interview"],
+    ["interview", "evaluation"],
+    ["evaluation", "offer"],
+    ["offer", "hired"],
+  ];
+  const illegal: [string, string][] = [
+    ["submitted", "interview"],
+    ["submitted", "hired"],
+    ["screening", "offer"],
+    ["rejected", "screening"], // terminal
+    ["hired", "offer"], // terminal
+    ["withdrawn", "submitted"], // terminal
+  ];
+
+  for (const [from, to] of legal) {
+    it(`allows ${from} → ${to}`, () => {
+      expect(ALLOWED_TRANSITIONS[from as keyof typeof ALLOWED_TRANSITIONS]).toContain(to);
+    });
+  }
+  for (const [from, to] of illegal) {
+    it(`forbids ${from} → ${to}`, () => {
+      expect(ALLOWED_TRANSITIONS[from as keyof typeof ALLOWED_TRANSITIONS]).not.toContain(to);
+    });
+  }
+
+  it("terminal stages have no outgoing transitions", () => {
+    expect(ALLOWED_TRANSITIONS.rejected).toEqual([]);
+    expect(ALLOWED_TRANSITIONS.hired).toEqual([]);
+    expect(ALLOWED_TRANSITIONS.withdrawn).toEqual([]);
+  });
+
+  it("withdrawn is reachable from every non-terminal stage", () => {
+    const nonTerminal = PIPELINE_STAGES.filter(
+      (s) => !["rejected", "hired", "withdrawn"].includes(s),
+    );
+    for (const s of nonTerminal) {
+      expect(ALLOWED_TRANSITIONS[s]).toContain("withdrawn");
+    }
+  });
+});
+
+describe("legacy status sync map", () => {
+  const expected: Record<string, string> = {
+    submitted: "submitted",
+    screening: "under_review",
+    shortlisted: "shortlisted",
+    interview: "interviewed",
+    evaluation: "under_review",
+    offer: "shortlisted",
+    hired: "accepted",
+    rejected: "rejected",
+    withdrawn: "withdrawn",
+  };
+  for (const stage of PIPELINE_STAGES) {
+    it(`${stage} → ${expected[stage]}`, () => {
+      expect(LEGACY_STATUS_MAP[stage]).toBe(expected[stage]);
+    });
+  }
+});
+
+describe("isValidStage", () => {
+  it("accepts known stages and rejects unknown", () => {
+    expect(isValidStage("submitted")).toBe(true);
+    expect(isValidStage("nope")).toBe(false);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -16,5 +16,27 @@ export default defineConfig({
     exclude: ["node_modules/**", "dist/**", "src/__tests__/**"],
     testTimeout: 20000,
     hookTimeout: 60000,
+    coverage: {
+      provider: "v8",
+      // Gate only the code we're actively building under test discipline (recruitment). The rest
+      // of the backend is intentionally ungated for now — no forced backfill. Widen the include
+      // glob as other areas grow real suites.
+      include: [
+        "src/services/recruitment/**",
+        "src/controllers/recruitment.ts",
+        "src/controllers/recruitment-pipeline.ts",
+        "src/db/schema/recruitment/**",
+      ],
+      reporter: ["text-summary"],
+      thresholds: {
+        // Per-glob 90% floor for recruitment code; CI fails the run if any drops below.
+        "src/services/recruitment/**": {
+          statements: 90,
+          branches: 90,
+          functions: 90,
+          lines: 90,
+        },
+      },
+    },
   },
 });

--- a/docs/architecture/testing-strategy.md
+++ b/docs/architecture/testing-strategy.md
@@ -59,5 +59,9 @@ Each spec lists tests to write FIRST. The implementing agent:
 - PR: prettier check, eslint, typecheck, unit + integration tests, build — all via
   `turbo run` with `--filter=...[origin/dev]` (affected only).
 - dev/main merge: everything + Playwright e2e.
-- Coverage: no hard global threshold initially; each spec's acceptance criteria are the bar.
-  Revisit once the suite exists.
+- Coverage: **no global threshold** (most of the repo predates test discipline — we don't
+  backfill on unrelated work). Instead a **scoped ratchet**: code under active TDD is gated at
+  **90%** (statements, branches, functions, lines) and CI fails below it. Currently enforced on
+  the backend's `src/services/recruitment/**` (REC-\*). Widen the glob + thresholds in
+  `backend/vitest.config.ts` as other areas grow real suites — never lower an existing floor.
+  Run locally with `pnpm --filter ganzafrica-backend test:coverage`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,7 +575,7 @@ importers:
         version: link:../../packages/typescript-config
       eslint:
         specifier: ^9.15.0
-        version: 9.39.4(jiti@1.21.7)
+        version: 9.39.4(jiti@2.7.0)
       postcss:
         specifier: ^8
         version: 8.5.14
@@ -681,7 +681,7 @@ importers:
         version: 0.6.2
       '@next/third-parties':
         specifier: latest
-        version: 16.2.6(next@16.1.6(@playwright/test@1.61.1)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1))(react@19.0.0-rc.1)
+        version: 16.2.10(next@16.1.6(@playwright/test@1.61.1)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1))(react@19.0.0-rc.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.3
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)
@@ -969,6 +969,9 @@ importers:
       '@types/uuid':
         specifier: ^9.0.8
         version: 9.0.8
+      '@vitest/coverage-v8':
+        specifier: '3'
+        version: 3.2.7(vitest@3.2.7(@types/node@20.19.41)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))
       '@workspace/eslint-config':
         specifier: workspace:*
         version: link:../packages/eslint-config
@@ -1177,7 +1180,7 @@ importers:
         version: 10.5.0(postcss@8.5.14)
       eslint:
         specifier: ^9.15.0
-        version: 9.39.4(jiti@2.7.0)
+        version: 9.39.4(jiti@1.21.7)
       postcss:
         specifier: ^8.4.33
         version: 8.5.14
@@ -1217,6 +1220,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@apidevtools/json-schema-ref-parser@9.1.2':
     resolution: {integrity: sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==}
@@ -1278,6 +1285,7 @@ packages:
   '@aws-sdk/core@3.974.9':
     resolution: {integrity: sha512-bXxosFunr+v/kqNb99r1NRkrVBha7CG036fRSpWGbC1A/e363XFQN6wcZMx7MYTdRr1tYwNnkrWX2xc1rT3BCQ==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.8':
     resolution: {integrity: sha512-fVfUCL/Xh2zINYMPZvj+iBn6XWouQf0DAnjaWCI9MkmqXzL2Iy5FoQB8O7syFe6gN6AH1ecDDU58T51Ou0kFkA==}
@@ -1596,6 +1604,10 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2606,6 +2618,14 @@ packages:
   '@internationalized/string@3.2.9':
     resolution: {integrity: sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2837,8 +2857,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/third-parties@16.2.6':
-    resolution: {integrity: sha512-PDPIPVj1NX6Taxsl8OJteAUJ7iwR+QrokwWig68eh0cOmuNjC6MBL+ZzBjO8Bv0n/HOSqjGArZpM5KMSUxm+MQ==}
+  '@next/third-parties@16.2.10':
+    resolution: {integrity: sha512-H3yxCMLziM1JKXnjQv83WBH2cp1fB1vMxpC1/bBTpvvaesBEuRuprpzq5RI32atis0VhUZflgdpJdGNZIGpQaQ==}
     peerDependencies:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
@@ -2909,6 +2929,10 @@ packages:
     peerDependencies:
       react: '>= 16.8'
       react-dom: '>= 16.8'
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@playwright/test@1.61.1':
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
@@ -5302,6 +5326,15 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -5582,6 +5615,9 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -5664,6 +5700,9 @@ packages:
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -6321,6 +6360,9 @@ packages:
   duplexer3@0.1.5:
     resolution: {integrity: sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -6814,6 +6856,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -6964,9 +7010,14 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globalize@0.1.1:
     resolution: {integrity: sha512-5e01v8eLGfuQSOvx2MsDMOWS0GFtCx1wPzQSmcHw4hkxFzrQDBO3Xwg/m8Hr/7qXMrHeOIE29qWVzyv06u1TZA==}
@@ -7087,6 +7138,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
@@ -7421,9 +7475,28 @@ packages:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
@@ -7442,9 +7515,13 @@ packages:
 
   jpeg-exif@1.1.4:
     resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   js-cookie@2.2.1:
     resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7709,6 +7786,9 @@ packages:
     resolution: {integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==}
     engines: {node: '>=0.10.0'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
     engines: {node: 20 || >=22}
@@ -7751,6 +7831,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
@@ -7851,8 +7938,16 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -8183,6 +8278,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
@@ -8252,6 +8350,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -9155,6 +9257,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -9388,6 +9494,10 @@ packages:
     resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -9947,6 +10057,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -10088,6 +10202,11 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@apidevtools/json-schema-ref-parser@9.1.2':
     dependencies:
@@ -10539,8 +10658,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -10592,7 +10711,7 @@ snapshots:
   '@babel/helper-module-imports@7.28.6':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10658,7 +10777,7 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.3':
     dependencies:
@@ -10713,8 +10832,8 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -10727,9 +10846,9 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -10755,6 +10874,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -11492,6 +11613,17 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.21
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -11662,7 +11794,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.2.1':
     optional: true
 
-  '@next/third-parties@16.2.6(next@16.1.6(@playwright/test@1.61.1)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1))(react@19.0.0-rc.1)':
+  '@next/third-parties@16.2.10(next@16.1.6(@playwright/test@1.61.1)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1))(react@19.0.0-rc.1)':
     dependencies:
       next: 16.1.6(@playwright/test@1.61.1)(react-dom@19.0.0-rc.1(react@19.0.0-rc.1))(react@19.0.0-rc.1)
       react: 19.0.0-rc.1
@@ -11719,6 +11851,9 @@ snapshots:
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@playwright/test@1.61.1':
     dependencies:
@@ -14773,6 +14908,25 @@ snapshots:
       next: 16.2.1(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@20.19.41)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@20.19.41)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(msw@2.14.6(@types/node@20.19.41)(typescript@5.9.3))(terser@5.47.1)(tsx@4.22.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -15123,6 +15277,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
@@ -15217,6 +15377,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -15763,6 +15927,8 @@ snapshots:
 
   duplexer3@0.1.5: {}
 
+  eastasianwidth@0.2.0: {}
+
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -16055,7 +16221,7 @@ snapshots:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -16073,7 +16239,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
@@ -16099,22 +16265,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.4(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -16129,14 +16280,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -16161,7 +16327,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -16179,7 +16345,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -16667,6 +16833,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -16828,6 +16999,15 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.1.6:
     dependencies:
       fs.realpath: 1.0.0
@@ -16973,6 +17153,8 @@ snapshots:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-to-text@9.0.5:
     dependencies:
@@ -17277,6 +17459,27 @@ snapshots:
 
   isexe@3.1.5: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -17285,6 +17488,12 @@ snapshots:
       get-proto: 1.0.1
       has-symbols: 1.1.0
       set-function-name: 2.0.2
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jest-worker@27.5.1:
     dependencies:
@@ -17301,6 +17510,8 @@ snapshots:
   jpeg-exif@1.1.4: {}
 
   js-cookie@2.2.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -17561,6 +17772,8 @@ snapshots:
 
   lowercase-keys@1.0.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.5.1: {}
 
   lru-cache@5.1.1:
@@ -17598,6 +17811,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.0
 
   markdown-it@14.1.1:
     dependencies:
@@ -17669,7 +17892,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   mkdirp@0.5.6:
     dependencies:
@@ -18080,6 +18309,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   pako@0.2.9: {}
 
   pako@1.0.11: {}
@@ -18138,6 +18369,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -19484,6 +19720,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -19760,6 +20002,12 @@ snapshots:
       acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   thenify-all@1.6.0:
     dependencies:
@@ -20410,6 +20658,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
Implements [REC-02](docs/specs/recruitment/REC-02-pipeline-backend.md) — a CRM-style staged recruitment pipeline built additively on the existing `applications` table. Backend-only (UI is REC-03); inert until then. Also introduces a **scoped 90% coverage gate** for recruitment code.

Depends on REC-01 (merged, #222) + FND-05. Blocks REC-03, REC-05.

---

### Schema (additive-only — migration `0005_recruitment_pipeline`)
- `applications` gains `pipeline_stage` (the pipeline's truth), `rejection_reason`, `flagged`, `flag_note` — nullable/defaulted, legacy rows untouched.
- `application_stage_events` — append-only audit trail (actor NULL = automation).
- `screening_rules` — `auto_reject` | `flag`, REC-01 operator vocabulary.
- `evaluation_criteria` + `application_scores` — weighted, per-reviewer, one row per (application, criterion, reviewer).
- `recruitment_emails` — unique per (application, email_type): the idempotency guard.

### Service (`services/recruitment/pipeline.service.ts`)
- `ALLOWED_TRANSITIONS` matrix + `LEGACY_STATUS_MAP` keeping the portal's `status` coherent.
- `transition()` — validates the matrix, **optimistic on the current stage** (0 rows → 409), writes application + stage event, syncs legacy status. The applicant email is **post-commit and non-blocking** — a mail failure never rolls back the move.
- `runScreening()` — post-insert, **wrapped so a screening error can never fail the submission**. `auto_reject` → rejected (actor NULL) + reason + optional email; `flag` → flagged + note.
- `sendApplicantEmail()` — insert idempotency row first, unique-violation → skip, then Resend.
- Weighted scoring: `Σ(score/max × weight) / Σweight`; reviewers edit only their own rows; `score > max_score` → 422.
- Branded email templates (`received`/`rejected`/`shortlisted`/`interview`/`offer`/`hired`); `rejected` uses HR-authored `rejection_reason` copy only (no rule internals).

Wired `runScreening` + the `received` email into REC-01's apply handler (non-fatal); the REC-01 characterization stays green.

### Routes (`/hr/recruitment/**`, `recruitment:manage`; lists also `recruitment:read` for director)
opportunities + per-stage counts · paged/filtered applications · full detail · `transition` (409 + `{allowed}` on illegal) · `rescreen` · screening-rule CRUD · criteria CRUD (block delete when scored) · scores upsert (reviewer own rows).

### Coverage gate (your ask)
A **scoped ratchet**, not a global threshold — no forced backfill of untested legacy code:
- Backend `src/services/recruitment/**` gated at **90%** (statements/branches/functions/lines) via vitest thresholds.
- New CI step `Recruitment coverage gate (backend ≥90%)` fails the run below it → can't merge to `dev`.
- Widen the glob/thresholds in `backend/vitest.config.ts` as other areas grow suites; never lower a floor. Documented in `docs/architecture/testing-strategy.md` §6. Run locally: `pnpm --filter ganzafrica-backend test:coverage`.

> **📣 Convention going forward — everyone please adopt this.** For **new/actively-built code**, add your area to the coverage `include` glob and hold it at **≥90%** (extend `thresholds` in `backend/vitest.config.ts`; frontend apps do the same in their own `vitest.config.ts`). This is the standard for all new work from here on — write the tests as you build, not after. We are **not** backfilling untested legacy code right now (no drift onto unrelated areas); a dedicated backfill pass to raise the floors repo-wide comes **later** as a separate effort. So: green ≥90% on what you touch, leave the rest for the backfill.

### Tests (§6 — 153 backend tests green)
Transition matrix + legacy sync map · transactionality (email failure doesn't roll back the stage) · auto_reject/flag screening (actor NULL, reason, one email) · screening **error-injection** (garbage operator → app stays submitted, apply still 2xx) · email idempotency (one row + one Resend call) · weighted score math (weights 2/1/1) + reviewer isolation + max_score 422 · legacy status sync per stage · permission matrix (staff 403, director read-only + 403 on transition). Plus `scripts/seed-recruitment-demo.ts` (one opportunity, form, rules, criteria, 12 applications across stages) for REC-03.

---

### CI note
The local pre-push typecheck hook flags **pre-existing** React 19 `@types` skew in `apps/task` and `@workspace/ui` (untouched by this PR) — the exact skew CI intentionally defers to FND-09 (`ci.yml` deliberately omits `typecheck`). CI's actual gates here — lint, test (incl. the new coverage gate), build — are green for this change.

### Rollout
Backend-only; inert until REC-03 UI lands. Seed script gives Track A a demo pipeline immediately.
